### PR TITLE
crds: move primaza.io.primaza.io to primaza.io

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the primaza.io v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=primaza.io.primaza.io
+// +groupName=primaza.io
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "primaza.io.primaza.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "primaza.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/config/crd/bases/primaza.io_clusterenvironments.yaml
+++ b/config/crd/bases/primaza.io_clusterenvironments.yaml
@@ -5,20 +5,21 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
-  name: serviceclasses.primaza.io.primaza.io
+  name: clusterenvironments.primaza.io
 spec:
-  group: primaza.io.primaza.io
+  group: primaza.io
   names:
-    kind: ServiceClass
-    listKind: ServiceClassList
-    plural: serviceclasses
-    singular: serviceclass
+    kind: ClusterEnvironment
+    listKind: ClusterEnvironmentList
+    plural: clusterenvironments
+    singular: clusterenvironment
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceClass is the Schema for the serviceclasses API
+        description: ClusterEnvironment is the Schema for the clusterenvironments
+          API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -33,15 +34,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServiceClassSpec defines the desired state of ServiceClass
+            description: ClusterEnvironmentSpec defines the desired state of ClusterEnvironment
             properties:
               foo:
-                description: Foo is an example field of ServiceClass. Edit serviceclass_types.go
+                description: Foo is an example field of ClusterEnvironment. Edit clusterenvironment_types.go
                   to remove/update
                 type: string
             type: object
           status:
-            description: ServiceClassStatus defines the observed state of ServiceClass
+            description: ClusterEnvironmentStatus defines the observed state of ClusterEnvironment
             type: object
         type: object
     served: true

--- a/config/crd/bases/primaza.io_registeredservices.yaml
+++ b/config/crd/bases/primaza.io_registeredservices.yaml
@@ -5,20 +5,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
-  name: serviceclaims.primaza.io.primaza.io
+  name: registeredservices.primaza.io
 spec:
-  group: primaza.io.primaza.io
+  group: primaza.io
   names:
-    kind: ServiceClaim
-    listKind: ServiceClaimList
-    plural: serviceclaims
-    singular: serviceclaim
+    kind: RegisteredService
+    listKind: RegisteredServiceList
+    plural: registeredservices
+    singular: registeredservice
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceClaim is the Schema for the serviceclaims API
+        description: RegisteredService is the Schema for the registeredservices API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -33,15 +33,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServiceClaimSpec defines the desired state of ServiceClaim
+            description: RegisteredServiceSpec defines the desired state of RegisteredService
             properties:
               foo:
-                description: Foo is an example field of ServiceClaim. Edit serviceclaim_types.go
+                description: Foo is an example field of RegisteredService. Edit registeredservice_types.go
                   to remove/update
                 type: string
             type: object
           status:
-            description: ServiceClaimStatus defines the observed state of ServiceClaim
+            description: RegisteredServiceStatus defines the observed state of RegisteredService
             type: object
         type: object
     served: true

--- a/config/crd/bases/primaza.io_servicebindings.yaml
+++ b/config/crd/bases/primaza.io_servicebindings.yaml
@@ -5,20 +5,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
-  name: servicecatalogs.primaza.io.primaza.io
+  name: servicebindings.primaza.io
 spec:
-  group: primaza.io.primaza.io
+  group: primaza.io
   names:
-    kind: ServiceCatalog
-    listKind: ServiceCatalogList
-    plural: servicecatalogs
-    singular: servicecatalog
+    kind: ServiceBinding
+    listKind: ServiceBindingList
+    plural: servicebindings
+    singular: servicebinding
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceCatalog is the Schema for the servicecatalogs API
+        description: ServiceBinding is the Schema for the servicebindings API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -33,15 +33,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServiceCatalogSpec defines the desired state of ServiceCatalog
+            description: ServiceBindingSpec defines the desired state of ServiceBinding
             properties:
               foo:
-                description: Foo is an example field of ServiceCatalog. Edit servicecatalog_types.go
+                description: Foo is an example field of ServiceBinding. Edit servicebinding_types.go
                   to remove/update
                 type: string
             type: object
           status:
-            description: ServiceCatalogStatus defines the observed state of ServiceCatalog
+            description: ServiceBindingStatus defines the observed state of ServiceBinding
             type: object
         type: object
     served: true

--- a/config/crd/bases/primaza.io_servicecatalogs.yaml
+++ b/config/crd/bases/primaza.io_servicecatalogs.yaml
@@ -5,20 +5,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
-  name: servicebindings.primaza.io.primaza.io
+  name: servicecatalogs.primaza.io
 spec:
-  group: primaza.io.primaza.io
+  group: primaza.io
   names:
-    kind: ServiceBinding
-    listKind: ServiceBindingList
-    plural: servicebindings
-    singular: servicebinding
+    kind: ServiceCatalog
+    listKind: ServiceCatalogList
+    plural: servicecatalogs
+    singular: servicecatalog
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceBinding is the Schema for the servicebindings API
+        description: ServiceCatalog is the Schema for the servicecatalogs API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -33,15 +33,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: ServiceBindingSpec defines the desired state of ServiceBinding
+            description: ServiceCatalogSpec defines the desired state of ServiceCatalog
             properties:
               foo:
-                description: Foo is an example field of ServiceBinding. Edit servicebinding_types.go
+                description: Foo is an example field of ServiceCatalog. Edit servicecatalog_types.go
                   to remove/update
                 type: string
             type: object
           status:
-            description: ServiceBindingStatus defines the observed state of ServiceBinding
+            description: ServiceCatalogStatus defines the observed state of ServiceCatalog
             type: object
         type: object
     served: true

--- a/config/crd/bases/primaza.io_serviceclaims.yaml
+++ b/config/crd/bases/primaza.io_serviceclaims.yaml
@@ -5,21 +5,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
-  name: clusterenvironments.primaza.io.primaza.io
+  name: serviceclaims.primaza.io
 spec:
-  group: primaza.io.primaza.io
+  group: primaza.io
   names:
-    kind: ClusterEnvironment
-    listKind: ClusterEnvironmentList
-    plural: clusterenvironments
-    singular: clusterenvironment
+    kind: ServiceClaim
+    listKind: ServiceClaimList
+    plural: serviceclaims
+    singular: serviceclaim
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterEnvironment is the Schema for the clusterenvironments
-          API
+        description: ServiceClaim is the Schema for the serviceclaims API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -34,15 +33,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: ClusterEnvironmentSpec defines the desired state of ClusterEnvironment
+            description: ServiceClaimSpec defines the desired state of ServiceClaim
             properties:
               foo:
-                description: Foo is an example field of ClusterEnvironment. Edit clusterenvironment_types.go
+                description: Foo is an example field of ServiceClaim. Edit serviceclaim_types.go
                   to remove/update
                 type: string
             type: object
           status:
-            description: ClusterEnvironmentStatus defines the observed state of ClusterEnvironment
+            description: ServiceClaimStatus defines the observed state of ServiceClaim
             type: object
         type: object
     served: true

--- a/config/crd/bases/primaza.io_serviceclasses.yaml
+++ b/config/crd/bases/primaza.io_serviceclasses.yaml
@@ -5,20 +5,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
-  name: registeredservices.primaza.io.primaza.io
+  name: serviceclasses.primaza.io
 spec:
-  group: primaza.io.primaza.io
+  group: primaza.io
   names:
-    kind: RegisteredService
-    listKind: RegisteredServiceList
-    plural: registeredservices
-    singular: registeredservice
+    kind: ServiceClass
+    listKind: ServiceClassList
+    plural: serviceclasses
+    singular: serviceclass
   scope: Namespaced
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: RegisteredService is the Schema for the registeredservices API
+        description: ServiceClass is the Schema for the serviceclasses API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -33,15 +33,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: RegisteredServiceSpec defines the desired state of RegisteredService
+            description: ServiceClassSpec defines the desired state of ServiceClass
             properties:
               foo:
-                description: Foo is an example field of RegisteredService. Edit registeredservice_types.go
+                description: Foo is an example field of ServiceClass. Edit serviceclass_types.go
                   to remove/update
                 type: string
             type: object
           status:
-            description: RegisteredServiceStatus defines the observed state of RegisteredService
+            description: ServiceClassStatus defines the observed state of ServiceClass
             type: object
         type: object
     served: true

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,12 +2,12 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/primaza.io.primaza.io_clusterenvironments.yaml
-- bases/primaza.io.primaza.io_registeredservices.yaml
-- bases/primaza.io.primaza.io_servicebindings.yaml
-- bases/primaza.io.primaza.io_servicecatalogs.yaml
-- bases/primaza.io.primaza.io_serviceclaims.yaml
-- bases/primaza.io.primaza.io_serviceclasses.yaml
+- bases/primaza.io_clusterenvironments.yaml
+- bases/primaza.io_registeredservices.yaml
+- bases/primaza.io_servicebindings.yaml
+- bases/primaza.io_servicecatalogs.yaml
+- bases/primaza.io_serviceclaims.yaml
+- bases/primaza.io_serviceclasses.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/crd/patches/cainjection_in_clusterenvironments.yaml
+++ b/config/crd/patches/cainjection_in_clusterenvironments.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: clusterenvironments.primaza.io.primaza.io
+  name: clusterenvironments.primaza.io

--- a/config/crd/patches/cainjection_in_registeredservices.yaml
+++ b/config/crd/patches/cainjection_in_registeredservices.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: registeredservices.primaza.io.primaza.io
+  name: registeredservices.primaza.io

--- a/config/crd/patches/cainjection_in_servicebindings.yaml
+++ b/config/crd/patches/cainjection_in_servicebindings.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: servicebindings.primaza.io.primaza.io
+  name: servicebindings.primaza.io

--- a/config/crd/patches/cainjection_in_servicecatalogs.yaml
+++ b/config/crd/patches/cainjection_in_servicecatalogs.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: servicecatalogs.primaza.io.primaza.io
+  name: servicecatalogs.primaza.io

--- a/config/crd/patches/cainjection_in_serviceclaims.yaml
+++ b/config/crd/patches/cainjection_in_serviceclaims.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: serviceclaims.primaza.io.primaza.io
+  name: serviceclaims.primaza.io

--- a/config/crd/patches/cainjection_in_serviceclasses.yaml
+++ b/config/crd/patches/cainjection_in_serviceclasses.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: serviceclasses.primaza.io.primaza.io
+  name: serviceclasses.primaza.io

--- a/config/crd/patches/webhook_in_clusterenvironments.yaml
+++ b/config/crd/patches/webhook_in_clusterenvironments.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterenvironments.primaza.io.primaza.io
+  name: clusterenvironments.primaza.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_registeredservices.yaml
+++ b/config/crd/patches/webhook_in_registeredservices.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: registeredservices.primaza.io.primaza.io
+  name: registeredservices.primaza.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_servicebindings.yaml
+++ b/config/crd/patches/webhook_in_servicebindings.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: servicebindings.primaza.io.primaza.io
+  name: servicebindings.primaza.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_servicecatalogs.yaml
+++ b/config/crd/patches/webhook_in_servicecatalogs.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: servicecatalogs.primaza.io.primaza.io
+  name: servicecatalogs.primaza.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_serviceclaims.yaml
+++ b/config/crd/patches/webhook_in_serviceclaims.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: serviceclaims.primaza.io.primaza.io
+  name: serviceclaims.primaza.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_serviceclasses.yaml
+++ b/config/crd/patches/webhook_in_serviceclasses.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: serviceclasses.primaza.io.primaza.io
+  name: serviceclasses.primaza.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/clusterenvironment_editor_role.yaml
+++ b/config/rbac/clusterenvironment_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: clusterenvironment-editor-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - clusterenvironments
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - clusterenvironments/status
   verbs:

--- a/config/rbac/clusterenvironment_viewer_role.yaml
+++ b/config/rbac/clusterenvironment_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: clusterenvironment-viewer-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - clusterenvironments
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - clusterenvironments/status
   verbs:

--- a/config/rbac/registeredservice_editor_role.yaml
+++ b/config/rbac/registeredservice_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: registeredservice-editor-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - registeredservices
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - registeredservices/status
   verbs:

--- a/config/rbac/registeredservice_viewer_role.yaml
+++ b/config/rbac/registeredservice_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: registeredservice-viewer-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - registeredservices
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - registeredservices/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,7 +6,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - clusterenvironments
   verbs:
@@ -18,13 +18,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - clusterenvironments/finalizers
   verbs:
   - update
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - clusterenvironments/status
   verbs:
@@ -32,7 +32,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicebindings
   verbs:
@@ -44,13 +44,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicebindings/finalizers
   verbs:
   - update
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicebindings/status
   verbs:
@@ -58,7 +58,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclaims
   verbs:
@@ -70,13 +70,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclaims/finalizers
   verbs:
   - update
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclaims/status
   verbs:
@@ -84,7 +84,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclasses
   verbs:
@@ -96,13 +96,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclasses/finalizers
   verbs:
   - update
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclasses/status
   verbs:

--- a/config/rbac/servicebinding_editor_role.yaml
+++ b/config/rbac/servicebinding_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: servicebinding-editor-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicebindings
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicebindings/status
   verbs:

--- a/config/rbac/servicebinding_viewer_role.yaml
+++ b/config/rbac/servicebinding_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: servicebinding-viewer-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicebindings
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicebindings/status
   verbs:

--- a/config/rbac/servicecatalog_editor_role.yaml
+++ b/config/rbac/servicecatalog_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: servicecatalog-editor-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicecatalogs
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicecatalogs/status
   verbs:

--- a/config/rbac/servicecatalog_viewer_role.yaml
+++ b/config/rbac/servicecatalog_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: servicecatalog-viewer-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicecatalogs
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - servicecatalogs/status
   verbs:

--- a/config/rbac/serviceclaim_editor_role.yaml
+++ b/config/rbac/serviceclaim_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: serviceclaim-editor-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclaims
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclaims/status
   verbs:

--- a/config/rbac/serviceclaim_viewer_role.yaml
+++ b/config/rbac/serviceclaim_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: serviceclaim-viewer-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclaims
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclaims/status
   verbs:

--- a/config/rbac/serviceclass_editor_role.yaml
+++ b/config/rbac/serviceclass_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: serviceclass-editor-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclasses
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclasses/status
   verbs:

--- a/config/rbac/serviceclass_viewer_role.yaml
+++ b/config/rbac/serviceclass_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: serviceclass-viewer-role
 rules:
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclasses
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - primaza.io.primaza.io
+  - primaza.io
   resources:
   - serviceclasses/status
   verbs:

--- a/config/samples/primaza.io_v1alpha1_clusterenvironment.yaml
+++ b/config/samples/primaza.io_v1alpha1_clusterenvironment.yaml
@@ -1,4 +1,4 @@
-apiVersion: primaza.io.primaza.io/v1alpha1
+apiVersion: primaza.io/v1alpha1
 kind: ClusterEnvironment
 metadata:
   labels:

--- a/config/samples/primaza.io_v1alpha1_registeredservice.yaml
+++ b/config/samples/primaza.io_v1alpha1_registeredservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: primaza.io.primaza.io/v1alpha1
+apiVersion: primaza.io/v1alpha1
 kind: RegisteredService
 metadata:
   labels:

--- a/config/samples/primaza.io_v1alpha1_servicebinding.yaml
+++ b/config/samples/primaza.io_v1alpha1_servicebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: primaza.io.primaza.io/v1alpha1
+apiVersion: primaza.io/v1alpha1
 kind: ServiceBinding
 metadata:
   labels:

--- a/config/samples/primaza.io_v1alpha1_servicecatalog.yaml
+++ b/config/samples/primaza.io_v1alpha1_servicecatalog.yaml
@@ -1,4 +1,4 @@
-apiVersion: primaza.io.primaza.io/v1alpha1
+apiVersion: primaza.io/v1alpha1
 kind: ServiceCatalog
 metadata:
   labels:

--- a/config/samples/primaza.io_v1alpha1_serviceclaim.yaml
+++ b/config/samples/primaza.io_v1alpha1_serviceclaim.yaml
@@ -1,4 +1,4 @@
-apiVersion: primaza.io.primaza.io/v1alpha1
+apiVersion: primaza.io/v1alpha1
 kind: ServiceClaim
 metadata:
   labels:

--- a/config/samples/primaza.io_v1alpha1_serviceclass.yaml
+++ b/config/samples/primaza.io_v1alpha1_serviceclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: primaza.io.primaza.io/v1alpha1
+apiVersion: primaza.io/v1alpha1
 kind: ServiceClass
 metadata:
   labels:

--- a/controllers/clusterenvironment_controller.go
+++ b/controllers/clusterenvironment_controller.go
@@ -33,9 +33,9 @@ type ClusterEnvironmentReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=clusterenvironments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=clusterenvironments/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=clusterenvironments/finalizers,verbs=update
+//+kubebuilder:rbac:groups=primaza.io,resources=clusterenvironments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=primaza.io,resources=clusterenvironments/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=primaza.io,resources=clusterenvironments/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/servicebinding_controller.go
+++ b/controllers/servicebinding_controller.go
@@ -33,9 +33,9 @@ type ServiceBindingReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=servicebindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=servicebindings/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=servicebindings/finalizers,verbs=update
+//+kubebuilder:rbac:groups=primaza.io,resources=servicebindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=primaza.io,resources=servicebindings/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=primaza.io,resources=servicebindings/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/serviceclaim_controller.go
+++ b/controllers/serviceclaim_controller.go
@@ -33,9 +33,9 @@ type ServiceClaimReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=serviceclaims,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=serviceclaims/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=serviceclaims/finalizers,verbs=update
+//+kubebuilder:rbac:groups=primaza.io,resources=serviceclaims,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=primaza.io,resources=serviceclaims/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=primaza.io,resources=serviceclaims/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/serviceclass_controller.go
+++ b/controllers/serviceclass_controller.go
@@ -33,9 +33,9 @@ type ServiceClassReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=serviceclasses,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=serviceclasses/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=primaza.io.primaza.io,resources=serviceclasses/finalizers,verbs=update
+//+kubebuilder:rbac:groups=primaza.io,resources=serviceclasses,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=primaza.io,resources=serviceclasses/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=primaza.io,resources=serviceclasses/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
When scaffolding out the resources, I included primaza.io in both the `operator-sdk init` and `operator-sdk create` commands.  This lead to primaza.io being duplicated in the CRDs.  Remove the duplication and migrate to *.primaza.io.

Signed-off-by: Andy Sadler <ansadler@redhat.com>