### PR TITLE
docker build cleanups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 # Ignore build and test binaries.
 bin/
 testbin/
+
+# ignore testing-related artifacts
+out/

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- docker buildx rm project-v3-builder
 	rm Dockerfile.cross
 


### PR DESCRIPTION
This fixes building with `make docker-buildx`, which was broken.  Docker was not sending the correct build context, since we were never informing it which directory it should use.

This also ignores `out/` directories during docker builds, which should speed up build times.  We don't need to send a python virtual environment & acceptance test outputs to docker when building; we solely depend on go code there.

Signed-off-by: Andy Sadler <ansadler@redhat.com>