### PR TITLE
deploy: wait for deployment to finish rollout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	kubectl rollout status -n primaza-system deploy/primaza-controller-manager -w --timeout=120s
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.


### PR DESCRIPTION
This appears to fix timeouts that could occur when setting up controllers.

Signed-off-by: Andy Sadler <ansadler@redhat.com>