### PR TITLE
Add test-acceptance-wip make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,12 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GO) test ./... -coverprofile cover.out
 
+.PHONY: test-acceptance-wip
+test-acceptance-wip: test-acceptance-setup ## Runs acceptance tests for WIP tagged scenarios
+	@(kind get clusters | grep primaza | xargs -I@ kind delete cluster --name @) || true
+	echo "Running work in progress acceptance tests"
+	$(PYTHON_VENV_DIR)/bin/behave --junit --junit-directory $(TEST_ACCEPTANCE_OUTPUT_DIR) --no-capture --no-capture-stderr $(TEST_ACCEPTANCE_TAGS_ARG) $(EXTRA_BEHAVE_ARGS) --wip --stop test/acceptance/features
+
 ##@ Build
 
 .PHONY: build

--- a/test/acceptance/features/environment.py
+++ b/test/acceptance/features/environment.py
@@ -14,16 +14,23 @@ before_all(context), after_all(context)
 
 
 from behave import fixture, use_fixture
-from steps.command import Command
 from steps.kind import KindProvider
 
-cmd = Command()
+
+def is_development(context):
+    return "wip" in context.tags and context._config.stop
 
 
 @fixture
 def use_kind(context, _timeout=30, **_kwargs):
     context.cluster_provider = KindProvider()
     yield context.cluster_provider
+
+    # if development configuration is found and scenario failed, skip cleanup
+    if is_development(context) and context.failed:
+        print("wip, stop config and context.failed found: not cleaning up")
+        return
+
     context.cluster_provider.delete_clusters()
 
 


### PR DESCRIPTION
This target can be used to easily test one or more scenarios during development.
Just tag the scenarios you're working on with `@wip` and execute `make test-acceptance-wip`. The test will stop at the first failure and won't perform cleanup.

Signed-off-by: Francesco Ilario <filario@redhat.com>