### PR TITLE
Agents deployment in linked clusters

### DIFF
--- a/cmd/agents/app/main.go
+++ b/cmd/agents/app/main.go
@@ -79,7 +79,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "859ca7e5.agentapp.primaza.io",
+		LeaderElectionID:       "859ca7e5.primaza.io",
 		Namespace:              ns,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the

--- a/config/agents/app/agentapp.yaml
+++ b/config/agents/app/agentapp.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-agentapp
+  name: primaza-controller-agentapp
   labels:
-    control-plane: controller-agentapp
+    control-plane: primaza-controller-agentapp
     app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: controller-agentapp
+    app.kubernetes.io/instance: primaza-controller-agentapp
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: primaza
     app.kubernetes.io/part-of: primaza
@@ -13,14 +13,14 @@ metadata:
 spec:
   selector:
     matchLabels:
-      control-plane: controller-agentapp
+      control-plane: primaza-controller-agentapp
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-agentapp
+        control-plane: primaza-controller-agentapp
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution. 
@@ -90,5 +90,5 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      serviceAccountName: controller-agentapp
+      serviceAccountName: primaza-controller-agentapp
       terminationGracePeriodSeconds: 10

--- a/config/agents/app/rbac/kustomization.yaml
+++ b/config/agents/app/rbac/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- rbac/
-- agentapp.yaml
+- role.yaml
+- role_binding.yaml
+- service_account.yaml
+

--- a/config/agents/app/rbac/role.yaml
+++ b/config/agents/app/rbac/role.yaml
@@ -20,6 +20,7 @@ rules:
   - primaza.io
   resources:
   - servicebindings
+  - serviceclaims
   verbs:
   - get
   - list

--- a/config/agents/app/rbac/role_binding.yaml
+++ b/config/agents/app/rbac/role_binding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: agentsvc-rolebinding
+    app.kubernetes.io/instance: agentapp-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: primaza
     app.kubernetes.io/part-of: primaza
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: agentsvc-role
+  name: agentapp-role
 subjects:
 - kind: ServiceAccount
-  name: controller-agentsvc
+  name: primaza-controller-agentapp

--- a/config/agents/app/rbac/service_account.yaml
+++ b/config/agents/app/rbac/service_account.yaml
@@ -3,9 +3,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-agentapp
+    app.kubernetes.io/instance: primaza-controller-agentapp
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: primaza
     app.kubernetes.io/part-of: primaza
     app.kubernetes.io/managed-by: kustomize
-  name: controller-agentapp
+  name: primaza-controller-agentapp

--- a/config/agents/svc/agentsvc.yaml
+++ b/config/agents/svc/agentsvc.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-agentsvc
+  name: primaza-controller-agentsvc
   labels:
-    control-plane: controller-agentsvc
+    control-plane: primaza-controller-agentsvc
     app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: controller-agentsvc
+    app.kubernetes.io/instance: primaza-controller-agentsvc
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: primaza
     app.kubernetes.io/part-of: primaza
@@ -13,14 +13,14 @@ metadata:
 spec:
   selector:
     matchLabels:
-      control-plane: controller-agentsvc
+      control-plane: primaza-controller-agentsvc
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-agentsvc
+        control-plane: primaza-controller-agentsvc
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution. 
@@ -90,5 +90,5 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      serviceAccountName: controller-agentsvc
+      serviceAccountName: primaza-controller-agentsvc
       terminationGracePeriodSeconds: 10

--- a/config/agents/svc/kustomization.yaml
+++ b/config/agents/svc/kustomization.yaml
@@ -1,11 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- rbac/
 - agentsvc.yaml
-- role.yaml
-- role_binding.yaml
-- service_account.yaml
-images:
-- name: controller
-  newName: agentsvc
-  newTag: latest
+

--- a/config/agents/svc/rbac/kustomization.yaml
+++ b/config/agents/svc/rbac/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- rbac/
-- agentapp.yaml
+- role.yaml
+- role_binding.yaml
+- service_account.yaml
+

--- a/config/agents/svc/rbac/role.yaml
+++ b/config/agents/svc/rbac/role.yaml
@@ -17,6 +17,25 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - primaza.io
+  resources:
+  - servicebindings
+  - serviceclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
   - ""
   resources:
   - events

--- a/config/agents/svc/rbac/role_binding.yaml
+++ b/config/agents/svc/rbac/role_binding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: agentapp-rolebinding
+    app.kubernetes.io/instance: agentsvc-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: primaza
     app.kubernetes.io/part-of: primaza
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: agentapp-role
+  name: agentsvc-role
 subjects:
 - kind: ServiceAccount
-  name: controller-agentapp
+  name: primaza-controller-agentsvc

--- a/config/agents/svc/rbac/service_account.yaml
+++ b/config/agents/svc/rbac/service_account.yaml
@@ -3,9 +3,9 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-agentsvc
+    app.kubernetes.io/instance: primaza-controller-agentsvc
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: primaza
     app.kubernetes.io/part-of: primaza
     app.kubernetes.io/managed-by: kustomize
-  name: controller-agentsvc
+  name: primaza-controller-agentsvc

--- a/config/rbac/application_agent_role.yaml
+++ b/config/rbac/application_agent_role.yaml
@@ -1,0 +1,22 @@
+# permissions for end users to edit servicebindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: application-agent-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: primaza
+    app.kubernetes.io/part-of: primaza
+    app.kubernetes.io/managed-by: kustomize
+  name: application-agent-role
+rules:
+- apiGroups:
+  - primaza.io
+  resources:
+  - serviceclaims
+  verbs:
+  - create
+  - delete
+  - patch
+  - update

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,6 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+# RBAC for agents
+- application_agent_role.yaml
+- service_agent_role.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - primaza.io
   resources:
@@ -168,3 +169,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/service_agent_role.yaml
+++ b/config/rbac/service_agent_role.yaml
@@ -1,0 +1,29 @@
+# permissions for end users to edit servicebindings.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: service-agent-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: primaza
+    app.kubernetes.io/part-of: primaza
+    app.kubernetes.io/managed-by: kustomize
+  name: service-agent-role
+rules:
+- apiGroups:
+  - primaza.io
+  resources:
+  - registeredservices
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - primaza.io
+  resources:
+  - registeredservices/status
+  verbs:
+  - get
+  - update

--- a/controllers/clusterenvironment_controller.go
+++ b/controllers/clusterenvironment_controller.go
@@ -18,20 +18,29 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	primazaiov1alpha1 "github.com/primaza/primaza/api/v1alpha1"
+	"github.com/primaza/primaza/pkg/primaza/controlplane"
+	"github.com/primaza/primaza/pkg/primaza/workercluster"
 )
+
+const clusterEnvironmentFinalizer = "clusterenvironment.primaza.io/finalizer"
+
+var errClusterContextSecretNotFound = fmt.Errorf("Cluster Context Secret not found")
 
 // ClusterEnvironmentReconciler reconciles a ClusterEnvironment object
 type ClusterEnvironmentReconciler struct {
@@ -39,7 +48,8 @@ type ClusterEnvironmentReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=primaza.io,resources=clusterenvironments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=primaza.io,resources=clusterenvironments/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=primaza.io,resources=clusterenvironments/finalizers,verbs=update
@@ -56,58 +66,111 @@ type ClusterEnvironmentReconciler struct {
 func (r *ClusterEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := log.FromContext(ctx)
 
-	var ce primazaiov1alpha1.ClusterEnvironment
-	if err := r.Client.Get(ctx, req.NamespacedName, &ce); err != nil {
-		l.Info("error fetching ClusterEnvironment (deleted)", "error", err)
+	// fetch the cluster environment
+	ce := &primazaiov1alpha1.ClusterEnvironment{}
+	if err := r.Client.Get(ctx, req.NamespacedName, ce); err != nil {
+		if apierrors.IsNotFound(err) {
+			l.Info("error fetching ClusterEnvironment (deleted)", "error", err)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+
+		l.Error(err, "Failed to get ClusterEnvironment")
+		return ctrl.Result{}, err
+	}
+
+	// check if instance is marked to be deleted
+	if ce.GetDeletionTimestamp() != nil {
+		if controllerutil.ContainsFinalizer(ce, clusterEnvironmentFinalizer) {
+			// run finalizer
+			if err := r.finalizeClusterEnvironment(ctx, ce); err != nil {
+				return ctrl.Result{}, err
+			}
+
+			// Remove finalizer from cluster environment
+			controllerutil.RemoveFinalizer(ce, clusterEnvironmentFinalizer)
+			if err := r.Update(ctx, ce); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 		return ctrl.Result{}, nil
 	}
 
-	res := r.testConnection(ctx, ce)
-	if err := r.updateClusterEnvironmentStatus(ctx, ce, res); err != nil {
+	// add finalizer if needed
+	if !controllerutil.ContainsFinalizer(ce, clusterEnvironmentFinalizer) {
+		controllerutil.AddFinalizer(ce, clusterEnvironmentFinalizer)
+		if err := r.Update(ctx, ce); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// test connection
+	if err := r.testConnection(ctx, ce); err != nil {
+		l.Error(err, "error testing connection")
 		return ctrl.Result{}, err
 	}
+
+	// reconcile namespaces
+	l.Info("reconciling namespaces",
+		"application namespaces", ce.Spec.ApplicationNamespaces,
+		"service namespaces", ce.Spec.ServiceNamespaces)
+	if err := r.reconcileNamespaces(ctx, ce); err != nil {
+		l.Error(err, "error reconciling namespaces")
+		return ctrl.Result{}, err
+	}
+	l.Info("namespaces reconciled")
 
 	return ctrl.Result{}, nil
 }
 
-type connectionStatus struct {
-	State   primazaiov1alpha1.ClusterEnvironmentState
-	Reason  string
-	Message string
+func (r *ClusterEnvironmentReconciler) reconcileNamespaces(ctx context.Context, ce *primazaiov1alpha1.ClusterEnvironment) error {
+	kcfg, err := r.getClusterRESTConfig(ctx, ce)
+	if err != nil {
+		return err
+	}
+
+	s := controlplane.ClusterEnvironmentState{
+		Name:                  ce.Name,
+		Namespace:             ce.Namespace,
+		ClusterConfig:         kcfg,
+		ApplicationNamespaces: ce.Spec.ApplicationNamespaces,
+		ServiceNamespaces:     ce.Spec.ServiceNamespaces,
+	}
+
+	nr, err := controlplane.NewNamespaceReconciler(s)
+	if err != nil {
+		return err
+	}
+
+	return nr.ReconcileNamespaces(ctx)
 }
 
-func (r *ClusterEnvironmentReconciler) testConnection(ctx context.Context, ce primazaiov1alpha1.ClusterEnvironment) connectionStatus {
-	l := log.FromContext(ctx)
-
-	c, err := r.getClusterClient(ctx, ce)
+func (r *ClusterEnvironmentReconciler) testConnection(ctx context.Context, ce *primazaiov1alpha1.ClusterEnvironment) error {
+	cfg, err := r.getClusterRESTConfig(ctx, ce)
 	if err != nil {
-		l.Error(err, "error creating the client", "clusterenvironment", ce)
-		return connectionStatus{
-			State:   primazaiov1alpha1.ClusterEnvironmentStateOffline,
-			Reason:  "ClientCreationError",
-			Message: fmt.Sprintf("error creating the client: %s", err),
+		if errors.Is(err, errClusterContextSecretNotFound) {
+			c := workercluster.ConnectionStatus{
+				State:   primazaiov1alpha1.ClusterEnvironmentStateOffline,
+				Reason:  "ClientCreationError",
+				Message: fmt.Sprintf("error creating the client: %s", err),
+			}
+			if err := r.updateClusterEnvironmentStatus(ctx, ce, c); err != nil {
+				return err
+			}
 		}
+
+		return err
 	}
 
-	v, err := c.ServerVersion()
-	if err != nil {
-		l.Error(err, "error asking server version")
-		return connectionStatus{
-			State:   primazaiov1alpha1.ClusterEnvironmentStateOffline,
-			Reason:  "ConnectionError",
-			Message: fmt.Sprintf("error connecting to target cluster: %s", err),
-		}
+	c := workercluster.TestConnection(ctx, cfg)
+
+	if err := r.updateClusterEnvironmentStatus(ctx, ce, c); err != nil {
+		return err
 	}
 
-	l.Info("server version", "version", v)
-	return connectionStatus{
-		State:   primazaiov1alpha1.ClusterEnvironmentStateOnline,
-		Reason:  "ConnectionSuccessful",
-		Message: fmt.Sprintf("successfully connected to target cluster: kubernetes version found %s", v),
-	}
+	return nil
 }
 
-func (r *ClusterEnvironmentReconciler) updateClusterEnvironmentStatus(ctx context.Context, ce primazaiov1alpha1.ClusterEnvironment, cs connectionStatus) error {
+func (r *ClusterEnvironmentReconciler) updateClusterEnvironmentStatus(ctx context.Context, ce *primazaiov1alpha1.ClusterEnvironment, cs workercluster.ConnectionStatus) error {
 	l := log.FromContext(ctx)
 
 	l.Info("updating cluster environment status", "clusterenvironment", ce.GetName(), "connection status", cs)
@@ -119,7 +182,7 @@ func (r *ClusterEnvironmentReconciler) updateClusterEnvironmentStatus(ctx contex
 		Status:  "True",
 	}
 	meta.SetStatusCondition(&ce.Status.Conditions, co)
-	if err := r.Client.Status().Update(ctx, &ce); err != nil {
+	if err := r.Client.Status().Update(ctx, ce); err != nil {
 		l.Error(err, "error updating cluster environment status", "connection status", cs)
 		return err
 	}
@@ -127,29 +190,49 @@ func (r *ClusterEnvironmentReconciler) updateClusterEnvironmentStatus(ctx contex
 	return nil
 }
 
-func (r *ClusterEnvironmentReconciler) getClusterClient(ctx context.Context, ce primazaiov1alpha1.ClusterEnvironment) (*kubernetes.Clientset, error) {
+func (r *ClusterEnvironmentReconciler) getClusterRESTConfig(ctx context.Context, ce *primazaiov1alpha1.ClusterEnvironment) (*rest.Config, error) {
 	kc, err := r.getKubeconfig(ctx, ce)
 	if err != nil {
 		return nil, err
 	}
 
-	cg, err := clientcmd.RESTConfigFromKubeConfig(kc)
-	if err != nil {
-		return nil, err
-	}
-
-	return kubernetes.NewForConfig(cg)
+	return clientcmd.RESTConfigFromKubeConfig(kc)
 }
 
-func (r *ClusterEnvironmentReconciler) getKubeconfig(ctx context.Context, ce primazaiov1alpha1.ClusterEnvironment) ([]byte, error) {
+func (r *ClusterEnvironmentReconciler) getKubeconfig(ctx context.Context, ce *primazaiov1alpha1.ClusterEnvironment) ([]byte, error) {
 	sn := ce.Spec.ClusterContextSecret
 	k := client.ObjectKey{Namespace: ce.Namespace, Name: sn}
 	var s corev1.Secret
 	if err := r.Client.Get(ctx, k, &s); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, errors.Join(errClusterContextSecretNotFound, err)
+		}
 		return nil, err
 	}
 
 	return s.Data["kubeconfig"], nil
+}
+
+func (r *ClusterEnvironmentReconciler) finalizeClusterEnvironment(ctx context.Context, ce *primazaiov1alpha1.ClusterEnvironment) error {
+	kcfg, err := r.getClusterRESTConfig(ctx, ce)
+	if err != nil {
+		return err
+	}
+
+	s := controlplane.ClusterEnvironmentState{
+		Name:                  ce.Name,
+		Namespace:             ce.Namespace,
+		ClusterConfig:         kcfg,
+		ApplicationNamespaces: []string{},
+		ServiceNamespaces:     []string{},
+	}
+
+	nr, err := controlplane.NewNamespaceReconciler(s)
+	if err != nil {
+		return err
+	}
+
+	return nr.ReconcileNamespaces(ctx)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/deploy/primaza/Dockerfile
+++ b/deploy/primaza/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY vendor/ vendor/
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
@@ -14,6 +15,7 @@ RUN go mod download
 # Copy the go source
 COPY cmd/primaza/main.go cmd/primaza/main.go
 COPY api/ api/
+COPY pkg/ pkg/
 COPY controllers/ controllers/
 
 # Build

--- a/pkg/primaza/constants/constants.go
+++ b/pkg/primaza/constants/constants.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	PrimazaNamespace = "primaza-system"
+)

--- a/pkg/primaza/constants/doc.go
+++ b/pkg/primaza/constants/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package constants contains Primaza's constants
+package constants

--- a/pkg/primaza/controlplane/doc.go
+++ b/pkg/primaza/controlplane/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controlplane contains code for setting up and running Primaza
+// control plane
+package controlplane

--- a/pkg/primaza/controlplane/kubernetes_clients.go
+++ b/pkg/primaza/controlplane/kubernetes_clients.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getInClusterClient() (client.Client, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(cfg, client.Options{})
+}

--- a/pkg/primaza/controlplane/namespaces_binder.go
+++ b/pkg/primaza/controlplane/namespaces_binder.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/primaza/primaza/pkg/primaza/workercluster"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type NamespacesBinder interface {
+	BindNamespaces(ctx context.Context, ceName string, ceNamespace string, namespaces []string) error
+}
+
+func NewApplicationNamespacesBinder(primazaClient client.Client, workerClient *kubernetes.Clientset) NamespacesBinder {
+	return &namespacesBinder{pcli: primazaClient, wcli: workerClient, kind: "application", pushAgent: workercluster.PushApplicationAgent}
+}
+
+func NewServiceNamespacesBinder(primazaClient client.Client, workerClient *kubernetes.Clientset) NamespacesBinder {
+	return &namespacesBinder{pcli: primazaClient, wcli: workerClient, kind: "service", pushAgent: workercluster.PushServiceAgent}
+}
+
+type namespacesBinder struct {
+	pcli client.Client
+	wcli *kubernetes.Clientset
+	kind string
+
+	pushAgent func(context.Context, *kubernetes.Clientset, string) error
+}
+
+func (b *namespacesBinder) BindNamespaces(ctx context.Context, ceName string, ceNamespace string, namespaces []string) error {
+	l := log.FromContext(ctx)
+
+	ens := []string{}
+	for _, ns := range namespaces {
+		if err := b.bindNamespace(ctx, ceName, ceNamespace, ns); err != nil {
+			ens = append(ens, ns)
+			l.Error(err, "error binding namespace", "cluster-environment", ceName, "namespace", ns)
+		}
+	}
+
+	if len(ens) != 0 {
+		return fmt.Errorf("error binding namespaces: %v", ens)
+	}
+	return nil
+}
+
+func (b *namespacesBinder) bindNamespace(ctx context.Context, ceName, ceNamespace string, namespace string) error {
+	if err := b.createRoleBinding(ctx, ceName, ceNamespace, namespace); err != nil {
+		return err
+	}
+
+	if err := b.pushAgent(ctx, b.wcli, namespace); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *namespacesBinder) createRoleBinding(ctx context.Context, ceName, ceNamespace, namespace string) error {
+	n := b.getRoleBindingName(ceName, namespace)
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n,
+			Namespace: ceNamespace,
+			Labels: map[string]string{
+				"app":                 "primaza",
+				"cluster-environment": ceName,
+				"namespace-type":      b.kind,
+				"namespace":           namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     fmt.Sprintf("primaza-%s-agent-role", b.kind),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "User",
+				Name:     n,
+			},
+		},
+	}
+
+	if err := b.pcli.Create(ctx, rb, &client.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (b *namespacesBinder) getRoleBindingName(ceName, namespace string) string {
+	return fmt.Sprintf("primaza-%s-%s", ceName, namespace)
+}

--- a/pkg/primaza/controlplane/namespaces_reconciler.go
+++ b/pkg/primaza/controlplane/namespaces_reconciler.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/primaza/primaza/pkg/slices"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type ClusterEnvironmentState struct {
+	Name          string
+	Namespace     string
+	ClusterConfig *rest.Config
+
+	ApplicationNamespaces []string
+	ServiceNamespaces     []string
+}
+
+type NamespacesReconciler interface {
+	ReconcileNamespaces(ctx context.Context) error
+}
+
+type namespacesReconciler struct {
+	pcli client.Client
+	env  ClusterEnvironmentState
+
+	appBinder NamespacesBinder
+	svcBinder NamespacesBinder
+
+	appUnbinder NamespacesUnbinder
+	svcUnbinder NamespacesUnbinder
+}
+
+func NewNamespaceReconciler(e ClusterEnvironmentState) (NamespacesReconciler, error) {
+	cli, err := getInClusterClient()
+	if err != nil {
+		return nil, err
+	}
+
+	wcli, err := kubernetes.NewForConfig(e.ClusterConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &namespacesReconciler{
+		pcli:        cli,
+		env:         e,
+		appBinder:   NewApplicationNamespacesBinder(cli, wcli),
+		appUnbinder: NewApplicationNamespacesUnbinder(cli, wcli),
+		svcBinder:   NewServiceNamespacesBinder(cli, wcli),
+		svcUnbinder: NewServiceNamespacesUnbinder(cli, wcli),
+	}, nil
+}
+
+func (r *namespacesReconciler) ReconcileNamespaces(ctx context.Context) error {
+	errs := []error{}
+
+	if err := r.bindNamespaces(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := r.unbindOrphanNamespaces(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errors.Join(errs...)
+}
+
+func (r *namespacesReconciler) bindNamespaces(ctx context.Context) error {
+	aerr := r.appBinder.BindNamespaces(ctx, r.env.Name, r.env.Namespace, r.env.ApplicationNamespaces)
+	serr := r.svcBinder.BindNamespaces(ctx, r.env.Name, r.env.Namespace, r.env.ServiceNamespaces)
+
+	return errors.Join(aerr, serr)
+}
+
+func (r *namespacesReconciler) unbindOrphanNamespaces(ctx context.Context) error {
+	aerr := r.unbindOrphanNamespacesForType(ctx, r.appUnbinder, "application", r.env.ApplicationNamespaces)
+	serr := r.unbindOrphanNamespacesForType(ctx, r.svcUnbinder, "service", r.env.ServiceNamespaces)
+
+	return errors.Join(aerr, serr)
+}
+
+func (r *namespacesReconciler) unbindOrphanNamespacesForType(ctx context.Context, ub NamespacesUnbinder, namespaceType string, namespaces []string) error {
+	nn, err := r.getOrphanNamespaces(ctx, r.env.Name, namespaceType, namespaces)
+	if err != nil {
+		return err
+	}
+	l := log.FromContext(ctx)
+	l.Info("unbinding orphan namespaces", "namespace-type", namespaceType, "orphan-namespaces", nn)
+
+	return ub.UnbindNamespaces(ctx, r.env.Name, r.env.Namespace, nn)
+}
+
+func (r *namespacesReconciler) getOrphanNamespaces(ctx context.Context, ceName string, namespaceType string, requestedNamespaces []string) ([]string, error) {
+	ann, err := r.getAuthorizedNamespaces(ctx, r.env.Name, namespaceType)
+	if err != nil {
+		return nil, err
+	}
+
+	return slices.SubtractStr(ann, requestedNamespaces), nil
+}
+
+func (r *namespacesReconciler) getAuthorizedNamespaces(ctx context.Context, ceName string, namespaceType string) ([]string, error) {
+	l := log.FromContext(ctx)
+
+	rbb := &rbacv1.RoleBindingList{}
+	ls := r.getRoleBindingsLabelSelectorOrDie(ceName, namespaceType)
+	if err := r.pcli.List(ctx, rbb, &client.ListOptions{LabelSelector: ls, Namespace: r.env.Namespace}); err != nil {
+		return nil, err
+	}
+
+	nss := []string{}
+	for _, rb := range rbb.Items {
+		for _, s := range rb.Subjects {
+			if !r.isPrimazaWorkerUser(ctx, s) {
+				continue
+			}
+
+			ns, ok := rb.GetLabels()["namespace"]
+			if !ok {
+				l.Error(fmt.Errorf("can't find namespace label in Primaza's agent Role Binding"), "role binding", rb)
+			}
+			nss = append(nss, ns)
+		}
+	}
+	return nss, nil
+}
+
+func (r *namespacesReconciler) isPrimazaWorkerUser(ctx context.Context, s rbacv1.Subject) bool {
+	return s.Kind == rbacv1.UserKind &&
+		s.APIGroup == rbacv1.GroupName &&
+		strings.HasPrefix(s.Name, "primaza-")
+}
+
+func (r *namespacesReconciler) getRoleBindingsLabelSelectorOrDie(ceName string, namespaceType string) labels.Selector {
+	newEqualRequirementOrDie := func(key, value string) *labels.Requirement {
+		lr, err := labels.NewRequirement(key, "=", []string{value})
+		if err != nil {
+			// not expecting to happen
+			panic(err)
+		}
+		return lr
+	}
+
+	return labels.NewSelector().
+		Add(*newEqualRequirementOrDie("app", "primaza")).
+		Add(*newEqualRequirementOrDie("cluster-environment", ceName)).
+		Add(*newEqualRequirementOrDie("namespace-type", namespaceType))
+}

--- a/pkg/primaza/controlplane/namespaces_unbinder.go
+++ b/pkg/primaza/controlplane/namespaces_unbinder.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/primaza/primaza/pkg/primaza/workercluster"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type NamespacesUnbinder interface {
+	UnbindNamespaces(context.Context, string, string, []string) error
+}
+
+func NewApplicationNamespacesUnbinder(primazaClient client.Client, workerClient *kubernetes.Clientset) NamespacesUnbinder {
+	return &namespacesUnbinder{pcli: primazaClient, wcli: workerClient, kind: "application", deleteAgent: workercluster.DeleteApplicationAgent}
+}
+
+func NewServiceNamespacesUnbinder(primazaClient client.Client, workerClient *kubernetes.Clientset) NamespacesUnbinder {
+	return &namespacesUnbinder{pcli: primazaClient, wcli: workerClient, kind: "service", deleteAgent: workercluster.DeleteServiceAgent}
+}
+
+type namespacesUnbinder struct {
+	pcli client.Client
+	wcli *kubernetes.Clientset
+	kind string
+
+	deleteAgent func(context.Context, *kubernetes.Clientset, string) error
+}
+
+func (b *namespacesUnbinder) UnbindNamespaces(ctx context.Context, ceName, ceNamespace string, namespaces []string) error {
+	l := log.FromContext(ctx)
+
+	ens := []string{}
+	for _, ns := range namespaces {
+		if err := b.unbindNamespace(ctx, ceName, ceNamespace, ns); err != nil {
+			ens = append(ens, ns)
+			l.Error(err, "error unbinding namespace", "cluster-environment", ceName, "namespace", ns)
+		}
+	}
+
+	if len(ens) != 0 {
+		return fmt.Errorf("error unbinding namespaces: %v", ens)
+	}
+
+	return nil
+}
+
+func (b *namespacesUnbinder) unbindNamespace(ctx context.Context, ceName, ceNamespace string, namespace string) error {
+	if err := b.deleteRoleBinding(ctx, ceName, ceNamespace, namespace); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if err := b.deleteAgent(ctx, b.wcli, namespace); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (b *namespacesUnbinder) deleteRoleBinding(ctx context.Context, ceName, ceNamespace, namespace string) error {
+	n := b.getRoleBindingName(ceName, namespace)
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n,
+			Namespace: ceNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     fmt.Sprintf("%s-agent-role", b.kind),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "User",
+				Name:     n,
+			},
+		},
+	}
+
+	if err := b.pcli.Delete(ctx, rb, &client.DeleteOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (b *namespacesUnbinder) getRoleBindingName(ceName, namespace string) string {
+	return fmt.Sprintf("primaza-%s-%s", ceName, namespace)
+}

--- a/pkg/primaza/workercluster/agentapp.go
+++ b/pkg/primaza/workercluster/agentapp.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workercluster
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+)
+
+func DeleteApplicationAgent(ctx context.Context, cli *kubernetes.Clientset, namespace string) error {
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		return fmt.Errorf("decoder error: %w", err)
+	}
+
+	decode := serializer.NewCodecFactory(s).UniversalDeserializer().Decode
+
+	obj, _, err := decode([]byte(agentAppDeployment), nil, nil)
+	if err != nil {
+		return fmt.Errorf("decoder error: %w", err)
+	}
+
+	dep := obj.(*appsv1.Deployment)
+	if err := cli.AppsV1().Deployments(namespace).Delete(ctx, dep.Name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("error deleting deployment: %w", err)
+	}
+
+	return nil
+}
+
+func PushApplicationAgent(ctx context.Context, cli *kubernetes.Clientset, namespace string) error {
+	if _, err := createAgentAppDeployment(ctx, cli, namespace); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func createAgentAppDeployment(ctx context.Context, cli *kubernetes.Clientset, namespace string) (*appsv1.Deployment, error) {
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		return nil, fmt.Errorf("decoder error: %w", err)
+	}
+	decode := serializer.NewCodecFactory(s).UniversalDeserializer().Decode
+
+	obj, _, err := decode([]byte(agentAppDeployment), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decoder error: %w", err)
+	}
+
+	dep := obj.(*appsv1.Deployment)
+	r, err := cli.AppsV1().Deployments(namespace).Create(ctx, dep, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error creating deployment: %w", err)
+	}
+
+	return r, nil
+}
+
+const agentAppDeployment string = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: primaza-controller-agentapp
+  labels:
+    control-plane: primaza-controller-agentapp
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: primaza-controller-agentapp
+    app.kubernetes.io/component: agentapp-manager
+    app.kubernetes.io/created-by: primaza
+    app.kubernetes.io/part-of: primaza
+spec:
+  selector:
+    matchLabels:
+      control-plane: primaza-controller-agentapp
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: primaza-controller-agentapp
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - command:
+        - /manager
+        args:
+        - --leader-elect
+        image: agentapp:latest
+        imagePullPolicy: IfNotPresent
+        name: manager
+        env:
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      serviceAccountName: primaza-agentapp
+      terminationGracePeriodSeconds: 10
+`

--- a/pkg/primaza/workercluster/agentsvc.go
+++ b/pkg/primaza/workercluster/agentsvc.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workercluster
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes"
+)
+
+func DeleteServiceAgent(ctx context.Context, cli *kubernetes.Clientset, namespace string) error {
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		return fmt.Errorf("decoder error: %w", err)
+	}
+	decode := serializer.NewCodecFactory(s).UniversalDeserializer().Decode
+
+	obj, _, err := decode([]byte(agentSvcDeployment), nil, nil)
+	if err != nil {
+		return fmt.Errorf("decoder error: %w", err)
+	}
+
+	dep := obj.(*appsv1.Deployment)
+	if err := cli.AppsV1().Deployments(namespace).Delete(ctx, dep.Name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("error deleting deployment: %w", err)
+	}
+
+	return nil
+}
+
+func PushServiceAgent(ctx context.Context, cli *kubernetes.Clientset, namespace string) error {
+	if _, err := createAgentSvcDeployment(ctx, cli, namespace); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func createAgentSvcDeployment(ctx context.Context, cli *kubernetes.Clientset, namespace string) (*appsv1.Deployment, error) {
+	s := runtime.NewScheme()
+	if err := appsv1.AddToScheme(s); err != nil {
+		return nil, fmt.Errorf("decoder error: %w", err)
+	}
+	decode := serializer.NewCodecFactory(s).UniversalDeserializer().Decode
+
+	obj, _, err := decode([]byte(agentSvcDeployment), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decoder error: %w", err)
+	}
+
+	dep := obj.(*appsv1.Deployment)
+	r, err := cli.AppsV1().Deployments(namespace).Create(ctx, dep, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error creating deployment: %w", err)
+	}
+
+	return r, nil
+}
+
+const agentSvcDeployment string = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: primaza-controller-agentsvc
+  labels:
+    control-plane: primaza-controller-agentsvc
+    svc.kubernetes.io/name: deployment
+    svc.kubernetes.io/instance: primaza-controller-agentsvc
+    svc.kubernetes.io/component: agentsvc-manager
+    svc.kubernetes.io/created-by: primaza
+    svc.kubernetes.io/part-of: primaza
+spec:
+  selector:
+    matchLabels:
+      control-plane: primaza-controller-agentsvc
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: primaza-controller-agentsvc
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - command:
+        - /manager
+        args:
+        - --leader-elect
+        image: agentsvc:latest
+        imagePullPolicy: IfNotPresent
+        name: manager
+        env:
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      serviceAccountName: primaza-agentsvc
+      terminationGracePeriodSeconds: 10
+`

--- a/pkg/primaza/workercluster/connection.go
+++ b/pkg/primaza/workercluster/connection.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workercluster
+
+import (
+	"context"
+	"fmt"
+
+	primazaiov1alpha1 "github.com/primaza/primaza/api/v1alpha1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type ConnectionStatus struct {
+	State   primazaiov1alpha1.ClusterEnvironmentState
+	Reason  string
+	Message string
+}
+
+func TestConnection(ctx context.Context, cfg *rest.Config) ConnectionStatus {
+	c, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return ConnectionStatus{
+			State:   primazaiov1alpha1.ClusterEnvironmentStateOffline,
+			Reason:  "ClientCreationError",
+			Message: fmt.Sprintf("error creating the client: %s", err),
+		}
+	}
+
+	v, err := c.ServerVersion()
+	if err != nil {
+		return ConnectionStatus{
+			State:   primazaiov1alpha1.ClusterEnvironmentStateOffline,
+			Reason:  "ConnectionError",
+			Message: fmt.Sprintf("error connecting to target cluster: %s", err),
+		}
+	}
+
+	return ConnectionStatus{
+		State:   primazaiov1alpha1.ClusterEnvironmentStateOnline,
+		Reason:  "ConnectionSuccessful",
+		Message: fmt.Sprintf("successfully connected to target cluster: kubernetes version found %s", v),
+	}
+}

--- a/pkg/primaza/workercluster/doc.go
+++ b/pkg/primaza/workercluster/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package workercluster contains code for interacting with a worker cluster
+package workercluster

--- a/pkg/slices/doc.go
+++ b/pkg/slices/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package slices contains code for working with slices
+package slices

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slices
+
+func SubtractStr(s1, s2 []string) []string {
+	m := map[string]struct{}{}
+	for _, s := range s1 {
+		m[s] = struct{}{}
+	}
+	for _, s := range s2 {
+		delete(m, s)
+	}
+
+	rs := make([]string, len(m))
+	c := 0
+	for k := range m {
+		rs[c] = k
+		c++
+	}
+	return rs
+}

--- a/test/acceptance/features/applicationAgentDeployment.feature
+++ b/test/acceptance/features/applicationAgentDeployment.feature
@@ -1,4 +1,3 @@
-@disabled
 Feature: Publish Application Agent to worker cluster
 
     Scenario: On Cluster Environment creation, Primaza Application Agent is successfully deployed to applications namespace
@@ -91,4 +90,36 @@ Feature: Publish Application Agent to worker cluster
             - applications
         """
         Then On Worker Cluster "primaza-worker", Primaza Application Agent is deployed into namespace "applications"
+
+    Scenario: On Cluster Environment deletion, Primaza Application Agent is successfully removed from application namespace
+
+        Given Primaza Cluster "primaza-main" is running
+        And   Worker Cluster "primaza-worker" for "primaza-main" is running
+        And   Clusters "primaza-main" and "primaza-worker" can communicate
+        And   On Primaza Cluster "primaza-main", Worker "primaza-worker"'s ClusterContext secret "primaza-kw" is published
+        And   On Worker Cluster "primaza-worker", application namespace "applications" exists
+        And   On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-worker
+            namespace: primaza-system
+        spec:
+            environmentName: dev
+            clusterContextSecret: primaza-kw
+            applicationNamespaces:
+            - applications
+        """
+        And On Worker Cluster "primaza-worker", Primaza Application Agent is deployed into namespace "applications"
+        When On Primaza Cluster "primaza-main", Resource is deleted
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-worker
+            namespace: primaza-system
+        """
+        Then On Worker Cluster "primaza-worker", Primaza Application Agent is not deployed into namespace "applications"
+
 

--- a/test/acceptance/features/registerService.feature
+++ b/test/acceptance/features/registerService.feature
@@ -32,7 +32,7 @@ Feature: Register a cloud service in Primaza cluster
         And On Primaza Cluster "primaza-main", ServiceCatalog "primaza-service-catalog" will contain RegisteredService "primaza-rsdb"
 
 
-Scenario: Cloud Service Registration, no Healthcheck provided and ServiceCatalog exists
+    Scenario: Cloud Service Registration, no Healthcheck provided and ServiceCatalog exists
         Given Primaza Cluster "primaza-main" is running
         And   On Primaza Cluster "primaza-main", Resource is created
         """
@@ -86,7 +86,7 @@ Scenario: Cloud Service Registration, no Healthcheck provided and ServiceCatalog
         And On Primaza Cluster "primaza-main", ServiceCatalog "primaza-service-catalog" will contain RegisteredService "primaza-rsdb"
 
 
-Scenario: Cloud Service Registration, no Healthcheck provided, ServiceCatalog exists, and Registered Service deleted
+    Scenario: Cloud Service Registration, no Healthcheck provided, ServiceCatalog exists, and Registered Service deleted
         Given Primaza Cluster "primaza-main" is running
         And   On Primaza Cluster "primaza-main", Resource is created
         """
@@ -140,7 +140,7 @@ Scenario: Cloud Service Registration, no Healthcheck provided, ServiceCatalog ex
         Then On Primaza Cluster "primaza-main", ServiceCatalog "primaza-service-catalog" will not contain RegisteredService "primaza-rsdb"
 
 
-Scenario: Cloud Service Registration, no Healthcheck provided, ServiceCatalog does not exists, and Registered Service deleted
+    Scenario: Cloud Service Registration, no Healthcheck provided, ServiceCatalog does not exists, and Registered Service deleted
         Given Primaza Cluster "primaza-main" is running
         And   On Primaza Cluster "primaza-main", Resource is created
         """

--- a/test/acceptance/features/serviceAgentDeployment.feature
+++ b/test/acceptance/features/serviceAgentDeployment.feature
@@ -1,4 +1,3 @@
-@disabled
 Feature: Publish Service Agent to worker cluster
 
     Scenario: On Cluster Environment creation, Primaza Service Agent is successfully deployed to services namespace
@@ -91,3 +90,34 @@ Feature: Publish Service Agent to worker cluster
             - services
         """
         Then On Worker Cluster "primaza-worker", Primaza Service Agent is deployed into namespace "services"
+
+    Scenario: On Cluster Environment deletion, Primaza Service Agent is successfully removed from service namespace
+
+        Given Primaza Cluster "primaza-main" is running
+        And   Worker Cluster "primaza-worker" for "primaza-main" is running
+        And   Clusters "primaza-main" and "primaza-worker" can communicate
+        And   On Primaza Cluster "primaza-main", Worker "primaza-worker"'s ClusterContext secret "primaza-kw" is published
+        And   On Worker Cluster "primaza-worker", service namespace "services" exists
+        And   On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-worker
+            namespace: primaza-system
+        spec:
+            environmentName: dev
+            clusterContextSecret: primaza-kw
+            serviceNamespaces:
+            - services
+        """
+        And On Worker Cluster "primaza-worker", Primaza Service Agent is deployed into namespace "services"
+        When On Primaza Cluster "primaza-main", Resource is deleted
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-worker
+            namespace: primaza-system
+        """
+        Then On Worker Cluster "primaza-worker", Primaza Service Agent is not deployed into namespace "services"

--- a/test/acceptance/features/steps/workercluster.py
+++ b/test/acceptance/features/steps/workercluster.py
@@ -157,7 +157,12 @@ class WorkerCluster(Cluster):
                 client.V1PolicyRule(
                     api_groups=["apps"],
                     resources=["deployments"],
-                    verbs=["get", "list", "watch", "create", "update", "patch", "delete"]),
+                    verbs=["create"]),
+                client.V1PolicyRule(
+                    api_groups=["apps"],
+                    resources=["deployments"],
+                    verbs=["delete"],
+                    resource_names=["primaza-controller-agentapp", "primaza-controller-agentsvc"]),
                 client.V1PolicyRule(
                     api_groups=["primaza.io"],
                     resources=["servicebindings"],


### PR DESCRIPTION
> Depends on #28 

[Story 1288](https://issues.redhat.com/browse/APPSVC-1288)

On Cluster Environment creation agents are pushed to its Service and Application namespaces.
When a namespace is added to a Cluster Environment Service or Application namespaces list, agents are pushed into it.
When a namespace is deleted from a Cluster Environment Service or Application namespaces list, agents are removed from it.
When a Cluster Environment is deleted, previously pushed agents are removed.


