### PR TITLE
Fix kubernetes API server crash in BDD tests

### DIFF
--- a/test/acceptance/features/registerWorkerCluster.feature
+++ b/test/acceptance/features/registerWorkerCluster.feature
@@ -37,6 +37,8 @@ Feature: Register a kubernetes cluster as Primaza Worker Cluster
         Then On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" state will eventually move to "Offline"
         And On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" last status condition has Type "Offline"
 
+    # TODO(filariow): enable this when permissions check is supported
+    @disabled
     Scenario: Primaza Cluster can contact Worker cluster, but has invalid credentials
         Given Primaza Cluster "primaza-main" is running
         And   Worker Cluster "primaza-worker" for "primaza-main" is running

--- a/test/acceptance/features/steps/kind.py
+++ b/test/acceptance/features/steps/kind.py
@@ -44,7 +44,7 @@ nodes:
     kind: "ClusterConfiguration"
     apiServer:
       extraArgs:
-        anonymous-auth: "false"
+        anonymous-auth: "true"
   {image}
 """
         print(kind_config)


### PR DESCRIPTION
Disabling anonymous access causes kubernetes API server to crash and the cluster to be unstable (see https://github.com/kubernetes/kubernetes/issues/43784).

This PR enables the anonymous access again and momentarily disables the test relying on this feature to be off.
The disabled test will be modified and enabled again in [Story 1272](https://issues.redhat.com/browse/APPSVC-1272).