### PR TITLE
Check Cluster Environment's namespaces permissions

### DIFF
--- a/api/v1alpha1/clusterenvironment_types.go
+++ b/api/v1alpha1/clusterenvironment_types.go
@@ -47,7 +47,7 @@ type ClusterEnvironmentSpec struct {
 // ClusterEnvironmentStatus defines the observed state of ClusterEnvironment
 type ClusterEnvironmentStatus struct {
 	// The State of the cluster environment
-	//+kubebuilder:validation:Enum=Online;Offline
+	//+kubebuilder:validation:Enum=Online;Offline;Partial
 	//+kubebuilder:default:=Offline
 	State ClusterEnvironmentState `json:"state"`
 
@@ -59,6 +59,7 @@ type ClusterEnvironmentState string
 
 const (
 	ClusterEnvironmentStateOnline  ClusterEnvironmentState = "Online"
+	ClusterEnvironmentStatePartial ClusterEnvironmentState = "Partial"
 	ClusterEnvironmentStateOffline ClusterEnvironmentState = "Offline"
 )
 

--- a/config/crd/bases/primaza.io_clusterenvironments.yaml
+++ b/config/crd/bases/primaza.io_clusterenvironments.yaml
@@ -147,6 +147,7 @@ spec:
                 enum:
                 - Online
                 - Offline
+                - Partial
                 type: string
             required:
             - conditions

--- a/pkg/authz/doc.go
+++ b/pkg/authz/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package authz contains code to check if user has given permissions
+package authz

--- a/pkg/authz/permissions.go
+++ b/pkg/authz/permissions.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authz
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestResourcePermissions(ctx context.Context, cfg *rest.Config, namespaces []string, permissions []ResourcePermissions) (map[string]NamespacedPermissionsReport, error) {
+	c, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error creating the client: %w", err)
+	}
+
+	return checkPermissions(ctx, c, namespaces, permissions), nil
+}
+
+func checkPermissions(ctx context.Context, c *kubernetes.Clientset, namespaces []string, permissions []ResourcePermissions) map[string]NamespacedPermissionsReport {
+	rr := map[string]NamespacedPermissionsReport{}
+	for _, ns := range namespaces {
+		rr[ns] = checkPermissionsInNamespace(ctx, c, ns, permissions)
+	}
+	return rr
+}
+
+func checkPermissionsInNamespace(ctx context.Context, c *kubernetes.Clientset, namespace string, permissions []ResourcePermissions) NamespacedPermissionsReport {
+	l := log.FromContext(ctx)
+	r := NamespacedPermissionsReport{}
+	for _, p := range permissions {
+		for _, np := range p.toNamespacedPermissions(namespace) {
+			ok, err := checkAccess(ctx, c, np)
+
+			switch {
+			case err != nil:
+				l.Error(err, "checking permission", "permission", np)
+				r.inError(np, err)
+				continue
+			case !ok:
+				l.Info("permission not granted", "permission", np)
+				r.failed(np)
+				continue
+			case ok:
+				l.Info("permission granted", "permission", np)
+				r.satisfied(np)
+				continue
+			}
+		}
+	}
+	return r
+}
+
+func checkAccess(ctx context.Context, c *kubernetes.Clientset, np NamespacedPermission) (bool, error) {
+	sar := np.selfSubjectAccessReview()
+
+	r, err := c.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, &sar, metav1.CreateOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	return r.Status.Allowed, nil
+}

--- a/pkg/authz/types.go
+++ b/pkg/authz/types.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authz
+
+import (
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ResourcePermissions struct {
+	Verbs    []string
+	Group    string
+	Version  string
+	Resource string
+	Name     string
+}
+
+func (r ResourcePermissions) toNamespacedPermissions(namespace string) []NamespacedPermission {
+	pp := make([]NamespacedPermission, len(r.Verbs))
+	for i, v := range r.Verbs {
+		pp[i] = NamespacedPermission{
+			Verb:      v,
+			Group:     r.Group,
+			Version:   r.Version,
+			Resource:  r.Resource,
+			Namespace: namespace,
+			Name:      r.Name,
+		}
+	}
+	return pp
+}
+
+type NamespacedPermission struct {
+	Verb      string
+	Group     string
+	Version   string
+	Resource  string
+	Namespace string
+	Name      string
+}
+
+func (p NamespacedPermission) String() string {
+	if p.Name == "" {
+		return fmt.Sprintf("%s %s.%s/%s in %s",
+			p.Verb, p.Resource, p.Group, p.Version, p.Namespace)
+	}
+
+	return fmt.Sprintf("%s %s.%s/%s %s in %s",
+		p.Verb, p.Resource, p.Group, p.Version, p.Name, p.Namespace)
+}
+
+func (np *NamespacedPermission) selfSubjectAccessReview() authorizationv1.SelfSubjectAccessReview {
+	return authorizationv1.SelfSubjectAccessReview{
+		ObjectMeta: metav1.ObjectMeta{Namespace: np.Namespace},
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Verb:      np.Verb,
+				Version:   np.Version,
+				Group:     np.Group,
+				Resource:  np.Resource,
+				Namespace: np.Namespace,
+				Name:      np.Name,
+			},
+		},
+	}
+}
+
+type NamespacedPermissionsReport struct {
+	Satisfied []NamespacedPermission
+	Failed    []NamespacedPermission
+	InError   map[NamespacedPermission]error
+}
+
+func (r *NamespacedPermissionsReport) AllSatisfied() bool {
+	return len(r.Failed) == 0 && len(r.InError) == 0
+}
+
+func (r *NamespacedPermissionsReport) satisfied(np NamespacedPermission) {
+	r.Satisfied = append(r.Satisfied, np)
+}
+
+func (r *NamespacedPermissionsReport) failed(np NamespacedPermission) {
+	r.Failed = append(r.Failed, np)
+}
+
+func (r *NamespacedPermissionsReport) inError(np NamespacedPermission, err error) {
+	if r.InError == nil {
+		r.InError = map[NamespacedPermission]error{}
+	}
+
+	r.InError[np] = err
+}

--- a/pkg/primaza/controlplane/permission_checker.go
+++ b/pkg/primaza/controlplane/permission_checker.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"context"
+
+	"github.com/primaza/primaza/pkg/authz"
+	wauthz "github.com/primaza/primaza/pkg/primaza/workercluster/authz"
+	"k8s.io/client-go/rest"
+)
+
+type AgentPermissionsChecker interface {
+	TestPermissions(ctx context.Context, namespaces []string) (AgentPermissionsCheckReport, error)
+}
+
+type AgentPermissionsCheckReport map[string]authz.NamespacedPermissionsReport
+
+func NewAgentAppPermissionsChecker(cfg *rest.Config) AgentPermissionsChecker {
+	return &agentPermissionsChecker{
+		cfg:                    cfg,
+		getResourcePermissions: wauthz.GetAgentAppRequiredPermissions,
+	}
+}
+
+func NewAgentSvcPermissionsChecker(cfg *rest.Config) AgentPermissionsChecker {
+	return &agentPermissionsChecker{
+		cfg:                    cfg,
+		getResourcePermissions: wauthz.GetAgentSvcRequiredPermissions,
+	}
+}
+
+type agentPermissionsChecker struct {
+	cfg                    *rest.Config
+	getResourcePermissions func() []authz.ResourcePermissions
+}
+
+func (c *agentPermissionsChecker) TestPermissions(ctx context.Context, namespaces []string) (AgentPermissionsCheckReport, error) {
+	pp := c.getResourcePermissions()
+	return authz.TestResourcePermissions(ctx, c.cfg, namespaces, pp)
+}

--- a/pkg/primaza/workercluster/authz/agents.go
+++ b/pkg/primaza/workercluster/authz/agents.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authz
+
+import (
+	"github.com/primaza/primaza/pkg/authz"
+)
+
+func GetAgentAppRequiredPermissions() []authz.ResourcePermissions {
+	return []authz.ResourcePermissions{
+		{
+			Verbs:    []string{"create"},
+			Version:  "",
+			Group:    "apps",
+			Resource: "deployments",
+		},
+		{
+			Verbs:    []string{"delete"},
+			Version:  "",
+			Group:    "apps",
+			Resource: "deployments",
+			Name:     "primaza-controller-agentapp",
+		},
+	}
+}
+
+func GetAgentSvcRequiredPermissions() []authz.ResourcePermissions {
+	return []authz.ResourcePermissions{
+		{
+			Verbs:    []string{"create"},
+			Version:  "",
+			Group:    "apps",
+			Resource: "deployments",
+		},
+		{
+			Verbs:    []string{"delete"},
+			Version:  "",
+			Group:    "apps",
+			Resource: "deployments",
+			Name:     "primaza-controller-agentsvc",
+		},
+	}
+}

--- a/pkg/primaza/workercluster/authz/doc.go
+++ b/pkg/primaza/workercluster/authz/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package authz contains code for authorization on a worker cluster
+package authz

--- a/pkg/primaza/workercluster/connection.go
+++ b/pkg/primaza/workercluster/connection.go
@@ -21,13 +21,22 @@ import (
 	"fmt"
 
 	primazaiov1alpha1 "github.com/primaza/primaza/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
+type ConnectionStatusReason string
+
+const (
+	ConnectionSuccessful ConnectionStatusReason = "ConnectionSuccessful"
+	ConnectionError      ConnectionStatusReason = "ConnectionError"
+	ClientCreationError  ConnectionStatusReason = "ClientCreationError"
+)
+
 type ConnectionStatus struct {
 	State   primazaiov1alpha1.ClusterEnvironmentState
-	Reason  string
+	Reason  ConnectionStatusReason
 	Message string
 }
 
@@ -36,7 +45,7 @@ func TestConnection(ctx context.Context, cfg *rest.Config) ConnectionStatus {
 	if err != nil {
 		return ConnectionStatus{
 			State:   primazaiov1alpha1.ClusterEnvironmentStateOffline,
-			Reason:  "ClientCreationError",
+			Reason:  ClientCreationError,
 			Message: fmt.Sprintf("error creating the client: %s", err),
 		}
 	}
@@ -45,14 +54,31 @@ func TestConnection(ctx context.Context, cfg *rest.Config) ConnectionStatus {
 	if err != nil {
 		return ConnectionStatus{
 			State:   primazaiov1alpha1.ClusterEnvironmentStateOffline,
-			Reason:  "ConnectionError",
+			Reason:  ConnectionError,
 			Message: fmt.Sprintf("error connecting to target cluster: %s", err),
 		}
 	}
 
 	return ConnectionStatus{
 		State:   primazaiov1alpha1.ClusterEnvironmentStateOnline,
-		Reason:  "ConnectionSuccessful",
+		Reason:  ConnectionSuccessful,
 		Message: fmt.Sprintf("successfully connected to target cluster: kubernetes version found %s", v),
 	}
+}
+
+func (c ConnectionStatus) Condition() metav1.Condition {
+	status := func() metav1.ConditionStatus {
+		if c.State == primazaiov1alpha1.ClusterEnvironmentStateOnline {
+			return metav1.ConditionTrue
+		}
+		return metav1.ConditionFalse
+	}()
+
+	m := metav1.Condition{
+		Type:    "Online",
+		Reason:  string(c.Reason),
+		Message: c.Message,
+		Status:  status,
+	}
+	return m
 }

--- a/test/acceptance/features/applicationNamespaces.feature
+++ b/test/acceptance/features/applicationNamespaces.feature
@@ -1,0 +1,58 @@
+Feature: Register a kubernetes cluster as Primaza Worker Cluster
+
+    Scenario: Cluster Environment status is Partial if Application namespaces permissions are missing
+
+        Given Primaza Cluster "primaza-main" is running
+        And   Worker Cluster "primaza-worker" for "primaza-main" is running
+        And   Clusters "primaza-main" and "primaza-worker" can communicate
+        And   On Primaza Cluster "primaza-main", Worker "primaza-worker"'s ClusterContext secret "primaza-kw" is published
+        And   On Worker Cluster "primaza-worker", application namespace "applications" exists
+        And   On Worker Cluster "primaza-worker", Resource is deleted
+        """
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+            name: primaza-rolebinding
+            namespace: applications
+        """
+        When On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-worker
+            namespace: primaza-system
+        spec:
+            environmentName: dev
+            clusterContextSecret: primaza-kw
+            applicationNamespaces:
+            - applications
+        """
+        Then On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" state will eventually move to "Partial"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ApplicationNamespacePermissionsRequired" has Status "True"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ServiceNamespacePermissionsRequired" has Status "False"
+
+    Scenario: Cluster Environment status is Online if Application namespaces permissions are present
+
+        Given Primaza Cluster "primaza-main" is running
+        And   Worker Cluster "primaza-worker" for "primaza-main" is running
+        And   Clusters "primaza-main" and "primaza-worker" can communicate
+        And   On Primaza Cluster "primaza-main", Worker "primaza-worker"'s ClusterContext secret "primaza-kw" is published
+        And   On Worker Cluster "primaza-worker", application namespace "applications" exists
+        When  On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-worker
+            namespace: primaza-system
+        spec:
+            environmentName: dev
+            clusterContextSecret: primaza-kw
+            applicationNamespaces:
+            - applications
+        """
+        Then On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" state will eventually move to "Online"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "Online" has Status "True"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ApplicationNamespacePermissionsRequired" has Status "False"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ServiceNamespacePermissionsRequired" has Status "False"

--- a/test/acceptance/features/clusterEnvironment.feature
+++ b/test/acceptance/features/clusterEnvironment.feature
@@ -17,13 +17,15 @@ Feature: Register a kubernetes cluster as Primaza Worker Cluster
             clusterContextSecret: primaza-kw
         """
         Then On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" state will eventually move to "Online"
-        And On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" last status condition has Type "Online"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "Online" has Status "True"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ApplicationNamespacePermissionsRequired" has Status "False"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ServiceNamespacePermissionsRequired" has Status "False"
 
     Scenario: Primaza Cluster can contact Worker cluster, but ClusterContext secret is missing
         Given Primaza Cluster "primaza-main" is running
         And   Worker Cluster "primaza-worker" for "primaza-main" is running
         And   Clusters "primaza-main" and "primaza-worker" can communicate
-        When On Primaza Cluster "primaza-main", Resource is created
+        When  On Primaza Cluster "primaza-main", Resource is created
         """
         apiVersion: primaza.io/v1alpha1
         kind: ClusterEnvironment
@@ -35,28 +37,7 @@ Feature: Register a kubernetes cluster as Primaza Worker Cluster
             clusterContextSecret: primaza-kw
         """
         Then On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" state will eventually move to "Offline"
-        And On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" last status condition has Type "Offline"
-
-    # TODO(filariow): enable this when permissions check is supported
-    @disabled
-    Scenario: Primaza Cluster can contact Worker cluster, but has invalid credentials
-        Given Primaza Cluster "primaza-main" is running
-        And   Worker Cluster "primaza-worker" for "primaza-main" is running
-        And   Clusters "primaza-main" and "primaza-worker" can communicate
-        And   On Primaza Cluster "primaza-main", an invalid Worker "primaza-worker"'s ClusterContext secret "primaza-kw" is published
-        When On Primaza Cluster "primaza-main", Resource is created
-        """
-        apiVersion: primaza.io/v1alpha1
-        kind: ClusterEnvironment
-        metadata:
-            name: primaza-worker
-            namespace: primaza-system
-        spec:
-            environmentName: dev
-            clusterContextSecret: primaza-kw
-        """
-        Then On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" state will eventually move to "Offline"
-        And On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" last status condition has Type "Offline"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "Online" has Status "False"
 
     Scenario: Cluster Environment is created outside of Primaza's namespace
         Given Primaza Cluster "primaza-main" is running

--- a/test/acceptance/features/serviceNamespaces.feature
+++ b/test/acceptance/features/serviceNamespaces.feature
@@ -1,0 +1,58 @@
+Feature: Register a kubernetes cluster as Primaza Worker Cluster
+
+    Scenario: Cluster Environment status is Partial if Service namespaces permissions are missing
+
+        Given Primaza Cluster "primaza-main" is running
+        And   Worker Cluster "primaza-worker" for "primaza-main" is running
+        And   Clusters "primaza-main" and "primaza-worker" can communicate
+        And   On Primaza Cluster "primaza-main", Worker "primaza-worker"'s ClusterContext secret "primaza-kw" is published
+        And   On Worker Cluster "primaza-worker", service namespace "services" exists
+        And   On Worker Cluster "primaza-worker", Resource is deleted
+        """
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        metadata:
+            name: primaza-rolebinding
+            namespace: services
+        """
+        When On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-worker
+            namespace: primaza-system
+        spec:
+            environmentName: dev
+            clusterContextSecret: primaza-kw
+            serviceNamespaces:
+            - services
+        """
+        Then On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" state will eventually move to "Partial"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ServiceNamespacePermissionsRequired" has Status "True"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ApplicationNamespacePermissionsRequired" has Status "False"
+
+    Scenario: Cluster Environment status is Online if Service namespaces permissions are present
+
+        Given Primaza Cluster "primaza-main" is running
+        And   Worker Cluster "primaza-worker" for "primaza-main" is running
+        And   Clusters "primaza-main" and "primaza-worker" can communicate
+        And   On Primaza Cluster "primaza-main", Worker "primaza-worker"'s ClusterContext secret "primaza-kw" is published
+        And   On Worker Cluster "primaza-worker", service namespace "services" exists
+        When  On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-worker
+            namespace: primaza-system
+        spec:
+            environmentName: dev
+            clusterContextSecret: primaza-kw
+            serviceNamespaces:
+            - services
+        """
+        Then On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" state will eventually move to "Online"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "Online" has Status "True"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ServiceNamespacePermissionsRequired" has Status "False"
+        And  On Primaza Cluster "primaza-main", ClusterEnvironment "primaza-worker" status condition with Type "ApplicationNamespacePermissionsRequired" has Status "False"

--- a/test/acceptance/features/steps/kind.py
+++ b/test/acceptance/features/steps/kind.py
@@ -68,7 +68,7 @@ nodes:
         output, exit_code = self.exec(f'kind delete cluster --name {self.cluster_name}')
         return output, exit_code
 
-    def kubeconfig(self, internal=False):
+    def kubeconfig(self, internal: bool = False) -> str:
         # To be used for test client to cluster communication
         cmd = f"kind get kubeconfig --name {self.cluster_name}"
 

--- a/test/acceptance/features/steps/kubernetescli.py
+++ b/test/acceptance/features/steps/kubernetescli.py
@@ -513,6 +513,17 @@ def on_primaza_cluster_apply_yaml(context, primaza_cluster):
 
 @step(u'On Primaza Cluster "{primaza_cluster}", Resource is deleted')
 def on_primaza_cluster_delete_yaml(context, primaza_cluster: str):
+    kubeconfig = context.cluster_provider.get_primaza_cluster(primaza_cluster).get_admin_kubeconfig()
+    __on_cluster_delete_yaml(context, kubeconfig)
+
+
+@step(u'On Worker Cluster "{worker_cluster}", Resource is deleted')
+def on_worker_cluster_delete_yaml(context, worker_cluster: str):
+    kubeconfig = context.cluster_provider.get_worker_cluster(worker_cluster).get_admin_kubeconfig()
+    __on_cluster_delete_yaml(context, kubeconfig)
+
+
+def __on_cluster_delete_yaml(context, kubeconfig: str):
     resource = substitute_scenario_id(context, context.text)
 
     metadata = yaml.full_load(resource)["metadata"]
@@ -520,7 +531,6 @@ def on_primaza_cluster_delete_yaml(context, primaza_cluster: str):
     ns = metadata["namespace"] if "namespace" in metadata else None
 
     with tempfile.NamedTemporaryFile() as tf:
-        kubeconfig = context.cluster_provider.get_primaza_cluster(primaza_cluster).get_admin_kubeconfig()
         tf.write(kubeconfig.encode("utf-8"))
         tf.flush()
 

--- a/test/acceptance/features/steps/workercluster.py
+++ b/test/acceptance/features/steps/workercluster.py
@@ -181,7 +181,7 @@ class WorkerCluster(Cluster):
                 name="primaza-role"),
             subjects=[
                 client.V1Subject(
-                    api_group="rbac.authorization.k8s.io",
+                    api_group="",
                     kind="User",
                     name="primaza")
             ])


### PR DESCRIPTION
Checks primaza identity's permissions for agent deployment in Cluster Environments namespaces.

Depends on #28 and #31
Includes #55 

