### PR TITLE
Make ghcr images public

### DIFF
--- a/.github/workflows/push-ghcr.yaml
+++ b/.github/workflows/push-ghcr.yaml
@@ -35,23 +35,32 @@ jobs:
 
       - name: Build Primaza Docker image
         run: |
-          IMG=$IMG_BASE:$(git rev-parse --short HEAD) make primaza docker-build && \
-            docker tag "$IMG_BASE:$(git rev-parse --short HEAD)" "$IMG_BASE:latest"
+          IMG="${IMG_BASE}:$(git rev-parse --short HEAD)" \
+            DOCKER_BUILD_ARGS="--label org.opencontainers.image.source=https://github.com/${REPO}/${IMG_NAME} -t ${IMG_BASE}:latest" \
+            make primaza docker-build
         env:
+          REPO: ${{ github.actor }}
+          IMG_NAME: ${{ env.IMAGE_NAME }}
           IMG_BASE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build AgentApp Docker image
         run: |
-          IMG=$IMG_BASE:$(git rev-parse --short HEAD) make agentapp docker-build && \
-            docker tag "$IMG_BASE:$(git rev-parse --short HEAD)" "$IMG_BASE:latest"
+          IMG="${IMG_BASE}:$(git rev-parse --short HEAD)" \
+            DOCKER_BUILD_ARGS="--label org.opencontainers.image.source=https://github.com/${REPO}/${IMG_NAME} -t ${IMG_BASE}:latest" \
+            make agentapp docker-build
         env:
+          REPO: ${{ github.actor }}
+          IMG_NAME: ${{ env.IMAGE_NAME }}-agentapp
           IMG_BASE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-agentapp
 
       - name: Build AgentSvc Docker image
         run: |
-          IMG=$IMG_BASE:$(git rev-parse --short HEAD) make agentsvc docker-build && \
-            docker tag "$IMG_BASE:$(git rev-parse --short HEAD)" "$IMG_BASE:latest"
+          IMG="${IMG_BASE}:$(git rev-parse --short HEAD)" \
+            DOCKER_BUILD_ARGS="--label org.opencontainers.image.source=https://github.com/${REPO}/${IMG_NAME} -t ${IMG_BASE}:latest" \
+            make agentsvc docker-build
         env:
+          REPO: ${{ github.actor }}
+          IMG_NAME: ${{ env.IMAGE_NAME }}-agentsvc
           IMG_BASE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-agentsvc
 
       - name: Push Docker images

--- a/make/agents/app/build.mk
+++ b/make/agents/app/build.mk
@@ -1,5 +1,6 @@
 ##@ Build
 
+DOCKER_BUILD_ARGS ?=
 AGENTSAPP_MAIN=./cmd/agents/app/main.go
 
 .PHONY: build
@@ -15,8 +16,8 @@ run: fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} -f ${AGENTAPP_DOCKERFILE} .
+	docker build $(DOCKER_BUILD_ARGS) -t $(IMG) -f $(AGENTAPP_DOCKERFILE) .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	docker push $(IMG)

--- a/make/agents/svc/build.mk
+++ b/make/agents/svc/build.mk
@@ -1,5 +1,6 @@
 ##@ Build
 
+DOCKER_BUILD_ARGS ?=
 AGENTSSVC_MAIN=./cmd/agents/svc/main.go
 
 .PHONY: build
@@ -15,8 +16,8 @@ run: fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} -f ${AGENTSVC_DOCKERFILE} .
+	docker build $(DOCKER_BUILD_ARGS) -t $(IMG) -f $(AGENTSVC_DOCKERFILE) .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	docker push $(IMG)

--- a/make/primaza/build.mk
+++ b/make/primaza/build.mk
@@ -1,4 +1,5 @@
 ##@ Build
+DOCKER_BUILD_ARGS ?=
 PRIMAZA_MAIN=./cmd/primaza/main.go
 
 .PHONY: build
@@ -14,11 +15,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} -f ${PRIMAZA_DOCKERFILE} .
+	docker build $(DOCKER_BUILD_ARGS) -t $(IMG) -f $(PRIMAZA_DOCKERFILE) .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	docker push $(IMG)
 
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:


### PR DESCRIPTION
Add `org.opencontainers.image.source` label in order to make pushed images public.
Ref https://github.com/orgs/primaza/packages/container/primaza/settings

Signed-off-by: Francesco Ilario <filario@redhat.com>
