### PR TITLE
continue testing even if another test fails

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -99,6 +99,7 @@ jobs:
 
     needs: features
     strategy:
+      fail-fast: false
       matrix:
         feature: ${{ fromJSON(needs.features.outputs.features) }}
 


### PR DESCRIPTION
Currently, if an acceptance test fails, github will cancel all incomplete acceptance tests.  This, unfortunately, can obscure the effect of the change in question: since the tests don't run to completion, we don't necessarily understand what tests are and are not failing.

Change github's behavior to not cancel all test in the event of an early test failure.