### PR TITLE
Update RegisteredService state when Claims are successful

### DIFF
--- a/pkg/envtag/envtag.go
+++ b/pkg/envtag/envtag.go
@@ -30,6 +30,10 @@ const (
 
 // Match matches an environment against a list of constraints
 func Match(environment string, constraints []string) bool {
+	if len(constraints) == 0 {
+		return true
+	}
+
 	v := false
 	for _, m := range constraints {
 		switch match(environment, m) {

--- a/test/acceptance/features/serviceClaim.feature
+++ b/test/acceptance/features/serviceClaim.feature
@@ -74,6 +74,154 @@ Feature: Service claim with label selector
         """
         Then On Primaza Cluster "primaza-main", the status of ServiceClaim "sc-test" is "Resolved"
         And On Primaza Cluster, "primaza-main", the secret "sc-test" has the key "type" with value "psqlserver"
+        And On Primaza Cluster "primaza-main", RegisteredService "primaza-rsdb" state will eventually move to "Claimed"
+        And On Primaza Cluster "primaza-main", ServiceCatalog "primaza-service-catalog" will not contain RegisteredService "primaza-rsdb"
+
+
+    Scenario: Create a service claim with label selector, no constraints
+        Given Primaza Cluster "primaza-main" is running
+        And On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: RegisteredService
+        metadata:
+          name: primaza-rsdb
+          namespace: primaza-system
+        spec:
+          serviceClassIdentity:
+            - name: type
+              value: psqlserver
+            - name: provider
+              value: aws
+          serviceEndpointDefinition:
+            - name: host
+              value: mydavphost.io
+            - name: port
+              value: "5432"
+            - name: user
+              value: davp
+            - name: password
+              value: quedicelagente
+            - name: database
+              value: davpdata
+          sla: L3
+          """
+        And On Primaza Cluster "primaza-main", Primaza ClusterContext secret "primaza-km" is published
+        And On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-main
+            namespace: primaza-system
+        spec:
+            environmentName: stage
+            clusterContextSecret: primaza-km
+        """
+        And On Primaza Cluster "primaza-main", RegisteredService "primaza-rsdb" state will eventually move to "Available"
+        When On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ServiceClaim
+        metadata:
+          name: sc-test
+          namespace: primaza-system
+        spec:
+          serviceClassIdentity:
+          - name: type
+            value: psqlserver
+          - name: provider
+            value: aws
+          serviceEndpointDefinitionKeys:
+          - host
+          - port
+          - user
+          - password
+          - database
+          environmentTag: stage
+          application:
+            kind: Deployment
+            apiVersion: apps/v1
+            selector:
+              matchLabels:
+                a: b
+                c: d
+        """
+        Then On Primaza Cluster "primaza-main", the status of ServiceClaim "sc-test" is "Resolved"
+        And On Primaza Cluster, "primaza-main", the secret "sc-test" has the key "type" with value "psqlserver"
+        And On Primaza Cluster "primaza-main", RegisteredService "primaza-rsdb" state will eventually move to "Claimed"
+        And On Primaza Cluster "primaza-main", ServiceCatalog "primaza-service-catalog" will not contain RegisteredService "primaza-rsdb"
+
+
+    Scenario: Create a service claim with label selector, no constraints, sci subset and sed subset
+        Given Primaza Cluster "primaza-main" is running
+        And On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: RegisteredService
+        metadata:
+          name: primaza-rsdb
+          namespace: primaza-system
+        spec:
+          serviceClassIdentity:
+            - name: type
+              value: psqlserver
+            - name: provider
+              value: aws
+          serviceEndpointDefinition:
+            - name: host
+              value: mydavphost.io
+            - name: port
+              value: "5432"
+            - name: user
+              value: davp
+            - name: password
+              value: quedicelagente
+            - name: database
+              value: davpdata
+          sla: L3
+          """
+        And On Primaza Cluster "primaza-main", Primaza ClusterContext secret "primaza-km" is published
+        And On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: primaza-main
+            namespace: primaza-system
+        spec:
+            environmentName: stage
+            clusterContextSecret: primaza-km
+        """
+        And On Primaza Cluster "primaza-main", RegisteredService "primaza-rsdb" state will eventually move to "Available"
+        When On Primaza Cluster "primaza-main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ServiceClaim
+        metadata:
+          name: sc-test
+          namespace: primaza-system
+        spec:
+          serviceClassIdentity:
+          - name: type
+            value: psqlserver
+          serviceEndpointDefinitionKeys:
+          - host
+          - port
+          environmentTag: stage
+          application:
+            kind: Deployment
+            apiVersion: apps/v1
+            selector:
+              matchLabels:
+                a: b
+                c: d
+        """
+        Then On Primaza Cluster "primaza-main", the status of ServiceClaim "sc-test" is "Resolved"
+        And On Primaza Cluster, "primaza-main", the secret "sc-test" has the key "type" with value "psqlserver"
+        And On Primaza Cluster "primaza-main", RegisteredService "primaza-rsdb" state will eventually move to "Claimed"
+        And On Primaza Cluster "primaza-main", ServiceCatalog "primaza-service-catalog" will not contain RegisteredService "primaza-rsdb"
+
 
     Scenario: Create a service claim with non-existing SED key
         Given Primaza Cluster "primaza-main" is running
@@ -148,6 +296,9 @@ Feature: Service claim with label selector
                 c: d
         """
         Then On Primaza Cluster "primaza-main", the status of ServiceClaim "sc-test" is "Pending"
+        And On Primaza Cluster "primaza-main", RegisteredService "primaza-rsdb" state will eventually move to "Available"
+        And On Primaza Cluster "primaza-main", ServiceCatalog "primaza-service-catalog" will contain RegisteredService "primaza-rsdb"
+
 
     Scenario: Create a service claim with non-matching SCI
         Given Primaza Cluster "primaza-main" is running
@@ -222,3 +373,5 @@ Feature: Service claim with label selector
                 c: d
         """
         Then On Primaza Cluster "primaza-main", the status of ServiceClaim "sc-test" is "Pending"
+        And On Primaza Cluster "primaza-main", RegisteredService "primaza-rsdb" state will eventually move to "Available"
+        And On Primaza Cluster "primaza-main", ServiceCatalog "primaza-service-catalog" will contain RegisteredService "primaza-rsdb"


### PR DESCRIPTION
When a service claim is successful the matched regitered service state should be changed to "Claimed". This will make sure the service catalog does not contain the claimed service.