### PR TITLE
Add release latest manifests action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,42 @@
+name: Release Latest Manifests
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  TAG_NAME: latest
+
+jobs:
+  relase-latest-manifests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create or Update latest Tag
+        run: |
+          git tag -f ${{ env.TAG_NAME }}
+          git push origin -f ${{ env.TAG_NAME }}
+
+      - name: Bake manifests
+        run: |
+          make kustomize
+          mkdir -p out
+          ( cd config/manager && ../../bin/kustomize edit set image controller=${IMG} )
+          ./bin/kustomize build config/default > ./out/primaza.yaml
+        env:
+          IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Release manifests
+        uses: softprops/action-gh-release@v1
+        with:
+          name: latest
+          tag_name: ${{ env.TAG_NAME }}
+          files: |
+            ./out/primaza.yaml


### PR DESCRIPTION
Signed-off-by: Francesco Ilario <filario@redhat.com>

As a result the `latest` tag is created or updated to the latest commit in `main` branch and a Release named `latest` is created or updated.
Release's artifacts will contain a manifest (`primaza.yaml`) for deploying primaza using the `latest` images.