### PR TITLE
Fix permissions with periodic security checks

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,5 +1,9 @@
 name: Security checks
 
+permissions:
+  contents: read
+  security-events: write
+
 on: # yamllint disable-line rule:truthy
   pull_request: {}
   push:


### PR DESCRIPTION
The actions job needs the ability to write security events, which it doesn't get automatically.  In these cases, we need to give the job explicit permission to do so.