### PR TITLE
fix operator-sdk scaffolding

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -12,7 +12,6 @@ resources:
     namespaced: true
   controller: true
   domain: primaza.io
-  group: primaza.io
   kind: ClusterEnvironment
   path: github.com/primaza/primaza/api/v1alpha1
   version: v1alpha1
@@ -21,7 +20,6 @@ resources:
     namespaced: true
   controller: true
   domain: primaza.io
-  group: primaza.io
   kind: RegisteredService
   path: github.com/primaza/primaza/api/v1alpha1
   version: v1alpha1
@@ -30,7 +28,6 @@ resources:
     namespaced: true
   controller: true
   domain: primaza.io
-  group: primaza.io
   kind: ServiceBinding
   path: github.com/primaza/primaza/api/v1alpha1
   version: v1alpha1
@@ -38,7 +35,6 @@ resources:
     crdVersion: v1
     namespaced: true
   domain: primaza.io
-  group: primaza.io
   kind: ServiceCatalog
   path: github.com/primaza/primaza/api/v1alpha1
   version: v1alpha1
@@ -47,7 +43,6 @@ resources:
     namespaced: true
   controller: true
   domain: primaza.io
-  group: primaza.io
   kind: ServiceClaim
   path: github.com/primaza/primaza/api/v1alpha1
   version: v1alpha1
@@ -56,7 +51,6 @@ resources:
     namespaced: true
   controller: true
   domain: primaza.io
-  group: primaza.io
   kind: ServiceClass
   path: github.com/primaza/primaza/api/v1alpha1
   version: v1alpha1


### PR DESCRIPTION
When we invoke operator-sdk to introduce new project scaffolding, we run into the issue that it generates resources under the `primaza.io.primaza.io` group name, not `primaza.io`.  This is caused by a misconfiguration in the PROJECT file: we set both the domain and the group field for each resource, which is not correct in this circumstance.

To prevent problems from occuring in the future, remove the group field.