### PR TITLE
Implement SED secrets

### DIFF
--- a/api/v1alpha1/serviceclass_types.go
+++ b/api/v1alpha1/serviceclass_types.go
@@ -27,6 +27,11 @@ type ServiceClassMapping struct {
 	// JsonPath defines where data lives in the service resource.  This query
 	// must resolve to a single value (e.g. not an array of values).
 	JsonPath string `json:"jsonPath"`
+
+	// Secret indicates whether or not the mapping data needs to be stored in a secret.
+	// +optional
+	// +kubebuilder:default=true
+	Secret bool `json:"secret"`
 }
 
 // ServiceClassResource defines

--- a/config/crd/bases/primaza.io_serviceclasses.yaml
+++ b/config/crd/bases/primaza.io_serviceclasses.yaml
@@ -92,6 +92,11 @@ spec:
                         name:
                           description: Name of the data referred to
                           type: string
+                        secret:
+                          default: true
+                          description: Secret indicates whether or not the mapping
+                            data needs to be stored in a secret.
+                          type: boolean
                       required:
                       - jsonPath
                       - name

--- a/docs/entities/serviceclass.md
+++ b/docs/entities/serviceclass.md
@@ -11,6 +11,8 @@ The Primaza environment will push these resources to worker environments, where 
 Within a Service Class, there are two required properties:
 - `resource` defines the APIVersion and Kind of the resource to be transformed into a service mapping.
   It also contains a service endpoint definition mapping, which defines how binding information for a particular service may be obtained.
+  This mapping contains the name of the key and a json path defining where the corresponding data will be retrieved.
+  It also contains a `secret` flag which indicates whether this information should be stored in a secret, which defaults to true.
 - `serviceClassIdentity` defines a set of attributes that are sufficient to identify a Service Class.
   This field is copied to the generated registered services.
 


### PR DESCRIPTION
SED information could contain sensitive data, such as a password or authentication token.  Such data should not be stored within a registered service's resource itself.  When making registered services with a service class, we should give users the option to indicate that their data is secret.

This change introduces a `Secret` flag within a SED mapping, which indicates whether that particular mapping item should be stored within the registered service (false) or within an associated secret (true). By default, this flag is true, since security features such as this should be opt-out, not opt-in.