### PR TITLE
Remove duplicate serviceclaim role for app agent

### DIFF
--- a/config/agents/app/rbac/role.yaml
+++ b/config/agents/app/rbac/role.yaml
@@ -65,15 +65,6 @@ rules:
 - apiGroups:
   - primaza.io
   resources:
-  - serviceclaims
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-- apiGroups:
-  - primaza.io
-  resources:
   - servicebindings/finalizers
   verbs:
   - update


### PR DESCRIPTION
service claim role is was defined twice, once with delete and once without. 
Have removed the second one without delete as delete is required.