### PR TITLE
change agents to use published images

### DIFF
--- a/config/agents/app/agentapp.yaml
+++ b/config/agents/app/agentapp.yaml
@@ -59,7 +59,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: agentapp:latest
+        image: ghcr.io/primaza/primaza-agentapp:latest
         imagePullPolicy: IfNotPresent
         name: manager
         env:

--- a/config/agents/svc/agentsvc.yaml
+++ b/config/agents/svc/agentsvc.yaml
@@ -72,7 +72,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: agentsvc:latest
+        image: ghcr.io/primaza/primaza-agentsvc:latest
         imagePullPolicy: IfNotPresent
         name: manager
         env:


### PR DESCRIPTION
Primazactl needs to use published images. It does not install the agent app or svc images, primaza does.  Therefore primaza should use published images by default. Acceptance tests changes them back to local images.