### PR TITLE
Move from CSR to SA in Primaza's Control Plane

### DIFF
--- a/config/agents/svc/rbac/manager_role.yaml
+++ b/config/agents/svc/rbac/manager_role.yaml
@@ -41,3 +41,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - update
+  - patch
+  resourceNames:
+  - "primaza-svc-agent"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- manager_configmap.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -104,5 +104,15 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/primaza
+      volumes:
+      - name: config-volume
+        configMap:
+          name: primaza-manager
+          items:
+          - key: cluster_host_external
+            path: host
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager_configmap.yaml
+++ b/config/manager/manager_configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: manager
+  namespace: system
+data:
+  cluster_host_external: ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,8 +11,24 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - primaza.io

--- a/controllers/agents/svc/serviceclass_controller.go
+++ b/controllers/agents/svc/serviceclass_controller.go
@@ -46,7 +46,7 @@ import (
 // agents needs to write back registered services up to primaza.  It contains
 // two keys: `kubeconfig`, a serialized kubeconfig for the upstream kubeconfig
 // cluster, and `namespace`, the namespace to write registered services to
-const PRIMAZA_CONTROLLER_REFERENCE string = "primaza-kubeconfig"
+const PRIMAZA_CONTROLLER_REFERENCE string = "kubeconfig-primaza-svc"
 
 const finalizer = "serviceclasses.primaza.io/finalizer"
 

--- a/controllers/clusterenvironment_controller.go
+++ b/controllers/clusterenvironment_controller.go
@@ -65,7 +65,8 @@ type ClusterEnvironmentReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-//+kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",namespace=system,resources=serviceaccounts,verbs=create;delete;patch;update;get;list;watch
+//+kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=create;delete;patch;update;get;list;watch
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=system,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=primaza.io,namespace=system,resources=clusterenvironments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=primaza.io,namespace=system,resources=clusterenvironments/status,verbs=get;update;patch

--- a/pkg/identity/doc.go
+++ b/pkg/identity/doc.go
@@ -14,22 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controlplane
-
-type NamespaceType string
-
-const (
-	ServiceNamespaceType     NamespaceType = "service"
-	ApplicationNamespaceType NamespaceType = "application"
-)
-
-func (t NamespaceType) Short() string {
-	switch t {
-	case ServiceNamespaceType:
-		return "svc"
-	case ApplicationNamespaceType:
-		return "app"
-	default:
-		return string(t)
-	}
-}
+package identity

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	mv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Instance struct {
+	Namespace      string   `json:"namespace"`
+	ServiceAccount string   `json:"serviceAccount"`
+	Secrets        []string `json:"secrets"`
+}
+
+func Create(ctx context.Context, cli kubernetes.Clientset, name string, namespace string) (*Instance, error) {
+	sa, err := createServiceAccountIfNotExists(ctx, cli, name, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	sn := createSecretName(name)
+	if _, err := createServiceAccountSecret(ctx, cli, sn, namespace, sa); err != nil && !apierrors.IsAlreadyExists(err) {
+		return nil, err
+	}
+
+	return &Instance{
+		Namespace:      namespace,
+		ServiceAccount: name,
+		Secrets:        []string{sn},
+	}, nil
+}
+
+func DeleteIfExists(ctx context.Context, cli kubernetes.Clientset, name string, namespace string) error {
+	err := cli.CoreV1().ServiceAccounts(namespace).Delete(ctx, name, mv1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func createSecretName(sa string) string {
+	return fmt.Sprintf("tkn-%s", sa)
+}
+
+func createServiceAccountIfNotExists(ctx context.Context, cli kubernetes.Clientset, name string, namespace string) (*corev1.ServiceAccount, error) {
+	c := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	o := mv1.CreateOptions{}
+	sa, err := cli.CoreV1().ServiceAccounts(namespace).Create(ctx, c, o)
+	if err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+
+		return getServiceAccount(ctx, cli, name, namespace)
+	}
+
+	return sa, nil
+}
+
+func getServiceAccount(ctx context.Context, cli kubernetes.Clientset, name string, namespace string) (*corev1.ServiceAccount, error) {
+	return cli.CoreV1().ServiceAccounts(namespace).Get(ctx, name, mv1.GetOptions{})
+}
+
+func createServiceAccountSecret(ctx context.Context, cli kubernetes.Clientset, name string, namespace string, sa *corev1.ServiceAccount) (*corev1.Secret, error) {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: sa.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+					Name:       sa.Name,
+					UID:        sa.UID,
+				},
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	return cli.CoreV1().Secrets(namespace).Create(ctx, s, mv1.CreateOptions{})
+}

--- a/pkg/identity/kubeconfig.go
+++ b/pkg/identity/kubeconfig.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type GetKubeconfigOptions struct {
+	User      *string
+	Namespace *string
+}
+
+func GetKubeconfig(token *ServiceAccountToken, host string, opts GetKubeconfigOptions) ([]byte, error) {
+	cl := map[string]*clientcmdapi.Cluster{
+		"default-cluster": {
+			Server:                   host,
+			CertificateAuthorityData: token.CACrt,
+		},
+	}
+
+	un := "default-user"
+	if opts.User != nil {
+		un = *opts.User
+	}
+	ai := map[string]*clientcmdapi.AuthInfo{
+		un: {
+			Token: string(token.Token),
+		},
+	}
+
+	ct := map[string]*clientcmdapi.Context{
+		"default-context": {
+			Cluster:  "default-cluster",
+			AuthInfo: un,
+		},
+	}
+	if opts.Namespace != nil {
+		ct["default-context"].Namespace = *opts.Namespace
+	}
+
+	cc := clientcmdapi.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       cl,
+		Contexts:       ct,
+		AuthInfos:      ai,
+		CurrentContext: "default-context",
+	}
+
+	return clientcmd.Write(cc)
+}

--- a/pkg/identity/token.go
+++ b/pkg/identity/token.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The Primaza Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var ErrSecretMalformed = fmt.Errorf("service account's secret malformed")
+
+type ServiceAccountToken struct {
+	CACrt     []byte `json:"ca.crt"`
+	Namespace []byte `json:"namespace"`
+	Token     []byte `json:"token"`
+}
+
+func GetToken(secret *corev1.Secret) (*ServiceAccountToken, error) {
+	c, err := getSecretDataField(secret, "ca.crt")
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := getSecretDataField(secret, "namespace")
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := getSecretDataField(secret, "token")
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceAccountToken{
+		CACrt:     c,
+		Namespace: n,
+		Token:     t,
+	}, nil
+}
+
+func getSecretDataField(secret *corev1.Secret, field string) ([]byte, error) {
+	d, ok := secret.Data[field]
+	if !ok {
+		return nil, fmt.Errorf("%w: can not find '%s' in secret '%s/%s'", ErrSecretMalformed, field, secret.Namespace, secret.Name)
+	}
+
+	return d, nil
+}

--- a/pkg/primaza/controlplane/namespaces_binder.go
+++ b/pkg/primaza/controlplane/namespaces_binder.go
@@ -21,11 +21,15 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/primaza/primaza/pkg/identity"
 	"github.com/primaza/primaza/pkg/primaza/workercluster"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -68,7 +72,12 @@ func (b *namespacesBinder) BindNamespaces(ctx context.Context, ceName string, ce
 }
 
 func (b *namespacesBinder) bindNamespace(ctx context.Context, ceName, ceNamespace string, namespace string) error {
-	if err := b.createRoleBindings(ctx, ceName, ceNamespace, namespace); err != nil {
+	i, err := b.createIdentity(ctx, ceName, ceNamespace, namespace)
+	if err != nil {
+		return err
+	}
+
+	if err := b.pushKubeconfigSecret(ctx, i, namespace); err != nil {
 		return err
 	}
 
@@ -79,18 +88,100 @@ func (b *namespacesBinder) bindNamespace(ctx context.Context, ceName, ceNamespac
 	return nil
 }
 
-func (b *namespacesBinder) createRoleBindings(ctx context.Context, ceName, ceNamespace, namespace string) error {
+func (b *namespacesBinder) pushKubeconfigSecret(ctx context.Context, i *identity.Instance, namespace string) error {
+	kcfg, err := b.buildIdentityKubeconfig(ctx, i, namespace)
+	if err != nil {
+		return err
+	}
+
+	n := "kubeconfig-primaza-" + b.kind.Short()
+	rs := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      n,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"kubeconfig": kcfg,
+			"namespace":  []byte(i.Namespace),
+		},
+	}
+	if _, err := b.wcli.CoreV1().Secrets(namespace).Create(ctx, &rs, metav1.CreateOptions{}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+
+		if _, err := b.wcli.CoreV1().Secrets(namespace).Update(ctx, &rs, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *namespacesBinder) buildIdentityKubeconfig(ctx context.Context, i *identity.Instance, namespace string) ([]byte, error) {
+	if len(i.Secrets) == 0 {
+		return nil, fmt.Errorf("no secret found for service account %s", i.ServiceAccount)
+	}
+
+	s := corev1.Secret{}
+	if err := b.pcli.Get(ctx, types.NamespacedName{Namespace: i.Namespace, Name: i.Secrets[0]}, &s); err != nil {
+		return nil, err
+	}
+
+	t, err := identity.GetToken(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := getExternalHost()
+	if err != nil {
+		return nil, err
+	}
+
+	return identity.GetKubeconfig(t, h, identity.GetKubeconfigOptions{
+		User:      &i.ServiceAccount,
+		Namespace: &i.Namespace,
+	})
+}
+
+func (b *namespacesBinder) createIdentity(ctx context.Context, ceName, ceNamespace, namespace string) (*identity.Instance, error) {
+	// get in cluster client
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	cli, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// create identity
+	n := getAgentIdentityName(b.kind, ceName, namespace)
+	i, err := identity.Create(ctx, *cli, n, ceNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// create role bindings
+	if err := b.createRoleBindings(ctx, ceName, ceNamespace, namespace, i.ServiceAccount); err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}
+
+func (b *namespacesBinder) createRoleBindings(ctx context.Context, ceName, ceNamespace, namespace, saname string) error {
 	rr := getAgentRoleNames(b.kind)
 	errs := []error{}
 	for _, r := range rr {
-		if err := b.createRoleBinding(ctx, ceName, ceNamespace, namespace, r); err != nil {
+		if err := b.createRoleBinding(ctx, ceName, ceNamespace, namespace, r, saname); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
 }
 
-func (b *namespacesBinder) createRoleBinding(ctx context.Context, ceName, ceNamespace, namespace, role string) error {
+func (b *namespacesBinder) createRoleBinding(ctx context.Context, ceName, ceNamespace, namespace, role, saname string) error {
 	n := bakeRoleBindingName(role, ceName, namespace)
 	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -113,12 +204,12 @@ func (b *namespacesBinder) createRoleBinding(ctx context.Context, ceName, ceName
 			{
 				APIGroup: rbacv1.GroupName,
 				Kind:     "User",
-				Name:     n,
+				Name:     fmt.Sprintf("primaza-%s-%s", ceName, namespace),
 			},
 			{
 				APIGroup: "",
 				Kind:     "ServiceAccount",
-				Name:     n,
+				Name:     saname,
 			},
 		},
 	}

--- a/pkg/primaza/controlplane/namespaces_unbinder.go
+++ b/pkg/primaza/controlplane/namespaces_unbinder.go
@@ -85,7 +85,6 @@ func (b *namespacesUnbinder) unbindNamespace(ctx context.Context, ceName, ceName
 	if err := b.deleteAgent(ctx, b.wcli, namespace); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
-
 	return nil
 }
 

--- a/pkg/primaza/controlplane/serviceclasses.go
+++ b/pkg/primaza/controlplane/serviceclasses.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	primazaiov1alpha1 "github.com/primaza/primaza/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -35,7 +36,9 @@ func PushServiceClassToNamespaces(ctx context.Context, cli client.Client, sc pri
 		}
 
 		if err := cli.Create(ctx, sccp, &client.CreateOptions{}); err != nil {
-			return err
+			if !apierrors.IsAlreadyExists(err) {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Move from Certificate Signing Requests (CSR) to Service Accounts (SA) for new Application and Service namespaces.

As of now, the CSR is created by `primazactl`.
As we are moving to SA and `primaza` is already authorized to create secrets on worker cluster, we can have `primaza` itself handle the life-cycle of the agent's Service Accounts.

This means that when a new Application or Service namespace is created, `primaza` create the Service Account, the Service Account Token (secret), bakes the kubeconfig and push it in the worker's namespace.
More precisely, ClusterEnvironment controller is in charge of pushing the kubeconfig secret to target namespaces.

Signed-off-by: Francesco Ilario <filario@redhat.com>
