### PR TITLE
Add runtime configuration for Control Plane

### DIFF
--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: primaza-manager-config
+data:
+  agentsvc-image: agentsvc:latest
+  agentapp-image: agentapp:latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,4 +1,17 @@
 resources:
 - manager.yaml
+- configmap.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+# use the following command to overwrite agent image names:\
+#
+# kustomize edit add configmap primaza-manager-config \
+#   --behavior merge --disableNameSuffixHash \
+#   --from-literal agentapp-image=ghcr.io/primaza/primaza-agentapp:latest \
+#   --from-literal agentsvc-image=ghcr.io/primaza/primaza-agentsvc:latest
+configMapGenerator:
+- behavior: merge
+  literals: []
+  name: primaza-manager-config
+  options:
+    disableNameSuffixHash: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -104,5 +104,15 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: AGENT_SVC_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                name: primaza-manager-config
+                key: agentsvc-image
+          - name: AGENT_APP_IMAGE
+            valueFrom:
+              configMapKeyRef:
+                name: primaza-manager-config
+                key: agentapp-image
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/controllers/clusterenvironment_controller.go
+++ b/controllers/clusterenvironment_controller.go
@@ -63,6 +63,9 @@ const (
 type ClusterEnvironmentReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	AppAgentImage string
+	SvcAgentImage string
 }
 
 //+kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=create;update;delete;get;list;watch
@@ -381,6 +384,8 @@ func (r *ClusterEnvironmentReconciler) reconcileNamespaces(
 		ClusterConfig:         cfg,
 		ApplicationNamespaces: ans,
 		ServiceNamespaces:     sns,
+		AppAgentImage:         r.AppAgentImage,
+		SvcAgentImage:         r.SvcAgentImage,
 	}
 
 	nr, err := controlplane.NewNamespaceReconciler(s)
@@ -515,6 +520,8 @@ func (r *ClusterEnvironmentReconciler) finalizeClusterEnvironmentInNamespaces(ct
 		ClusterConfig:         kcfg,
 		ApplicationNamespaces: []string{},
 		ServiceNamespaces:     []string{},
+		AppAgentImage:         r.AppAgentImage,
+		SvcAgentImage:         r.SvcAgentImage,
 	}
 
 	nr, err := controlplane.NewNamespaceReconciler(s)

--- a/pkg/primaza/controlplane/namespaces_reconciler.go
+++ b/pkg/primaza/controlplane/namespaces_reconciler.go
@@ -36,6 +36,9 @@ type ClusterEnvironmentState struct {
 
 	ApplicationNamespaces []string
 	ServiceNamespaces     []string
+
+	AppAgentImage string
+	SvcAgentImage string
 }
 
 type NamespacesReconciler interface {
@@ -67,9 +70,9 @@ func NewNamespaceReconciler(e ClusterEnvironmentState) (NamespacesReconciler, er
 	return &namespacesReconciler{
 		pcli:        cli,
 		env:         e,
-		appBinder:   NewApplicationNamespacesBinder(cli, wcli),
+		appBinder:   NewApplicationNamespacesBinder(cli, wcli, e.AppAgentImage),
 		appUnbinder: NewApplicationNamespacesUnbinder(cli, wcli),
-		svcBinder:   NewServiceNamespacesBinder(cli, wcli),
+		svcBinder:   NewServiceNamespacesBinder(cli, wcli, e.SvcAgentImage),
 		svcUnbinder: NewServiceNamespacesUnbinder(cli, wcli),
 	}, nil
 }

--- a/pkg/primaza/workercluster/agentapp.go
+++ b/pkg/primaza/workercluster/agentapp.go
@@ -50,14 +50,14 @@ func DeleteApplicationAgent(ctx context.Context, cli *kubernetes.Clientset, name
 	return nil
 }
 
-func PushApplicationAgent(ctx context.Context, cli *kubernetes.Clientset, namespace string, ceName string) error {
-	if err := createAgentAppDeployment(ctx, cli, namespace, ceName); err != nil && !errors.IsAlreadyExists(err) {
+func PushApplicationAgent(ctx context.Context, cli *kubernetes.Clientset, namespace string, ceName string, image string) error {
+	if err := createAgentAppDeployment(ctx, cli, namespace, ceName, image); err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 	return nil
 }
 
-func createAgentAppDeployment(ctx context.Context, cli *kubernetes.Clientset, namespace string, ceName string) error {
+func createAgentAppDeployment(ctx context.Context, cli *kubernetes.Clientset, namespace string, ceName string, image string) error {
 	s := runtime.NewScheme()
 	if err := appsv1.AddToScheme(s); err != nil {
 		return fmt.Errorf("decoder error: %w", err)
@@ -70,6 +70,7 @@ func createAgentAppDeployment(ctx context.Context, cli *kubernetes.Clientset, na
 	}
 
 	dep := obj.(*appsv1.Deployment)
+	dep.Spec.Template.Spec.Containers[0].Image = image
 	dep.ObjectMeta.Labels[constants.PrimazaClusterEnvironmentLabel] = ceName
 	if _, err := cli.AppsV1().Deployments(namespace).Create(ctx, dep, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("error creating deployment: %w", err)

--- a/pkg/primaza/workercluster/agentsvc.go
+++ b/pkg/primaza/workercluster/agentsvc.go
@@ -49,15 +49,15 @@ func DeleteServiceAgent(ctx context.Context, cli *kubernetes.Clientset, namespac
 	return nil
 }
 
-func PushServiceAgent(ctx context.Context, cli *kubernetes.Clientset, namespace string, ceName string) error {
-	if err := createAgentSvcDeployment(ctx, cli, namespace, ceName); err != nil && !errors.IsAlreadyExists(err) {
+func PushServiceAgent(ctx context.Context, cli *kubernetes.Clientset, namespace string, ceName string, image string) error {
+	if err := createAgentSvcDeployment(ctx, cli, namespace, ceName, image); err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 
 	return nil
 }
 
-func createAgentSvcDeployment(ctx context.Context, cli *kubernetes.Clientset, namespace string, ceName string) error {
+func createAgentSvcDeployment(ctx context.Context, cli *kubernetes.Clientset, namespace string, ceName string, image string) error {
 	s := runtime.NewScheme()
 	if err := appsv1.AddToScheme(s); err != nil {
 		return fmt.Errorf("decoder error: %w", err)
@@ -70,6 +70,7 @@ func createAgentSvcDeployment(ctx context.Context, cli *kubernetes.Clientset, na
 	}
 
 	dep := obj.(*appsv1.Deployment)
+	dep.Spec.Template.Spec.Containers[0].Image = image
 	dep.ObjectMeta.Labels[constants.PrimazaClusterEnvironmentLabel] = ceName
 	if _, err := cli.AppsV1().Deployments(namespace).Create(ctx, dep, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("error creating deployment: %w", err)

--- a/test/acceptance/features/multiclusterEnvironment.feature
+++ b/test/acceptance/features/multiclusterEnvironment.feature
@@ -1,0 +1,59 @@
+Feature: Multi-Cluster Environment setup
+
+    Scenario: A multi-cluster environment is correctly setup
+
+        Given Primaza Cluster "main" is running
+        And   Worker Cluster "worker" for ClusterEnvironment "worker" is running
+        And   On Primaza Cluster "main", Worker "worker"'s ClusterContext secret "primaza-kw" for ClusterEnvironment "worker" is published
+        And   On Worker Cluster "worker", application namespace "applications" for ClusterEnvironment "worker" exists
+        And   On Worker Cluster "worker", service namespace "services" for ClusterEnvironment "worker" exists
+        When  On Primaza Cluster "main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: worker
+            namespace: primaza-system
+        spec:
+            environmentName: dev
+            clusterContextSecret: primaza-kw
+            applicationNamespaces:
+            - applications
+            serviceNamespaces:
+            - services
+        """
+        Then On Primaza Cluster "main", ClusterEnvironment "worker" state will eventually move to "Online"
+        And  On Primaza Cluster "main", ClusterEnvironment "worker" status condition with Type "Online" has Status "True"
+        And  On Primaza Cluster "main", ClusterEnvironment "worker" status condition with Type "ApplicationNamespacePermissionsRequired" has Status "False"
+        And  On Primaza Cluster "main", ClusterEnvironment "worker" status condition with Type "ServiceNamespacePermissionsRequired" has Status "False"
+        And  On Worker Cluster "worker", Primaza Application Agent exists into namespace "applications"
+        And  On Worker Cluster "worker", Primaza Service Agent exists into namespace "services"
+
+    Scenario: A multi-cluster single-namespace environment is correctly setup
+
+        Given Primaza Cluster "main" is running
+        And   Worker Cluster "worker" for ClusterEnvironment "worker" is running
+        And   On Primaza Cluster "main", Worker "worker"'s ClusterContext secret "primaza-kw" for ClusterEnvironment "worker" is published
+        And   On Worker Cluster "worker", application namespace "myapp" for ClusterEnvironment "worker" exists
+        And   On Worker Cluster "worker", service namespace "myapp" for ClusterEnvironment "worker" exists
+        When  On Primaza Cluster "main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ClusterEnvironment
+        metadata:
+            name: worker
+            namespace: primaza-system
+        spec:
+            environmentName: dev
+            clusterContextSecret: primaza-kw
+            applicationNamespaces:
+            - myapp
+            serviceNamespaces:
+            - myapp
+        """
+        Then On Primaza Cluster "main", ClusterEnvironment "worker" state will eventually move to "Online"
+        And  On Primaza Cluster "main", ClusterEnvironment "worker" status condition with Type "Online" has Status "True"
+        And  On Primaza Cluster "main", ClusterEnvironment "worker" status condition with Type "ApplicationNamespacePermissionsRequired" has Status "False"
+        And  On Primaza Cluster "main", ClusterEnvironment "worker" status condition with Type "ServiceNamespacePermissionsRequired" has Status "False"
+        And  On Worker Cluster "worker", Primaza Application Agent exists into namespace "myapp"
+        And  On Worker Cluster "worker", Primaza Service Agent exists into namespace "myapp"


### PR DESCRIPTION
Depends on "Fix constants and manifests (#143)"

Introduces a ConfigMap for Primaza's Control Plane to use for customizing Agents' images
