### PR TITLE
Refactor agent setup & teardown

### DIFF
--- a/config/agents/app/rbac/manager_role.yaml
+++ b/config/agents/app/rbac/manager_role.yaml
@@ -9,12 +9,15 @@ rules:
   resources:
   - servicebindings
   - serviceclaims
+  - servicecatalogs
   verbs:
   - get
   - list
   - watch
   - update
+  - patch
   - delete
+  - deletecollection
 - apiGroups:
   - primaza.io
   resources:
@@ -67,14 +70,3 @@ rules:
   - servicebindings/finalizers
   verbs:
   - update
-- apiGroups:
-  - primaza.io
-  resources:
-  - servicecatalogs
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete

--- a/config/agents/svc/rbac/manager_role.yaml
+++ b/config/agents/svc/rbac/manager_role.yaml
@@ -12,6 +12,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/controllers/agents/svc/serviceclass_controller.go
+++ b/controllers/agents/svc/serviceclass_controller.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -52,9 +51,7 @@ const finalizer = "serviceclasses.primaza.io/finalizer"
 type ServiceClassReconciler struct {
 	client.Client
 	dynamic.Interface
-	RemoteScheme *runtime.Scheme
-	Mapper       meta.RESTMapper
-	informers    map[string]informer
+	informers map[string]informer
 }
 
 type informer struct {
@@ -255,7 +252,7 @@ func (r *ServiceClassReconciler) HandleRegisteredServices(ctx context.Context, s
 
 	remote_client, err := client.New(config, client.Options{
 		Scheme: r.Client.Scheme(),
-		Mapper: r.Mapper,
+		Mapper: r.Client.RESTMapper(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
We can do a few things more efficiently:
- call Client.DeleteAllOf to delete all resources in a namespace without potentially having a TOCTOU bug
- filter deployments so that only the agent deployment triggers the reconciler.
- remove unused fields from the service agent struct