### PR TITLE
automatically cancel superceded actions runs

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -8,6 +8,10 @@ on: # yamllint disable-line rule:truthy
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   GO111MODULE: "on"
   MINIKUBE_WANTUPDATENOTIFICATION: false

--- a/.github/workflows/push-ghcr.yaml
+++ b/.github/workflows/push-ghcr.yaml
@@ -4,6 +4,10 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches: ['main']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -11,6 +11,10 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *' # run at midnight daily
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   gosec:
     name: Gosec


### PR DESCRIPTION
I've noticed that when we push changes to a branch, CI continues running against stale commits.  These runs are redundant, and they tie up our CI resources (which aren't infinite).

This automatically cancels runs with the same head ref (e.g. a PR), which should shorten our wait times slightly.  This does _not_ cancel runs for branch pushes (e.g. pushing to `main`).

Docs: https://docs.github.com/en/actions/using-jobs/using-concurrency