### PR TITLE
Fix Primaza's ConfigMap name in manifests

### DIFF
--- a/config/manager/configmap.yaml
+++ b/config/manager/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: primaza-manager-config
+  name: manager-config
 data:
   agentsvc-image: agentsvc:latest
   agentapp-image: agentapp:latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,6 +12,6 @@ kind: Kustomization
 configMapGenerator:
 - behavior: merge
   literals: []
-  name: primaza-manager-config
+  name: manager-config
   options:
     disableNameSuffixHash: true


### PR DESCRIPTION
Prefix is added by kustomize when building manifests

Signed-off-by: Francesco Ilario <filario@redhat.com>
