### PR TITLE
add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    ignore:
+      # These projects usually require more manual intervention to bump than
+      # usual, so let's ignore them from normal dependabot updates for now.
+      - dependency-name: "k8s.io/*"
+      - dependency-name: "sigs.k8s.io/*"
+
+  - package-ecosystem: pip
+    directory: "test/acceptance/features/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: "hack/check-python/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: "deploy/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This has dependabot check for updates once a week.  This intentionally excludes packages under the `k8s.io` and `sigs.k8s.io` domain (e.g. `client-go` and `controller-runtime`), since these packages usually require a bit more work than usual to deal with updates.

This also installs update watches for our python dependencies, our docker files, and the actions in our github actions config.