### PR TITLE
pre-build images during acceptance testing

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -119,12 +119,45 @@ jobs:
           FEATURES=$(ls *.feature | jq -R -s -c 'split("\n")[:-1]')
           echo "features=$FEATURES" >> $GITHUB_OUTPUT
 
+  build:
+    name: Build images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - make: primaza
+            image-name: primaza-controller
+          - make: agentapp
+            image-name: agentapp
+          - make: agentsvc
+            image-name: agentsvc
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Checkout Git Repository
+        uses: actions/checkout@v3
+
+      - name: Build images
+        run: |
+          make ${{ matrix.make }} docker-build IMG=${{ matrix.image-name }}:latest
+          docker save ${{ matrix.image-name }}:latest -o ${{ matrix.image-name }}.tar
+
+      - name: Upload image artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: images
+          path: ${{ matrix.image-name }}.tar
+
   acceptance:
     name: Acceptance Tests
     runs-on: ubuntu-20.04
     timeout-minutes: 90
 
-    needs: features
+    needs: ["features", "build"]
     strategy:
       fail-fast: false
       matrix:
@@ -150,12 +183,25 @@ jobs:
         with:
           start-minikube: false
 
+      - name: Download pre-built images
+        uses: actions/download-artifact@v3
+        with:
+          name: images
+          path: images/
+
       - name: Acceptance tests
         timeout-minutes: 60
-        run: make kustomize test-acceptance
+        run: |
+          docker load -i images/primaza-controller.tar
+          docker load -i images/agentapp.tar
+          docker load -i images/agentsvc.tar
+          make kustomize test-acceptance
         env:
           EXTRA_BEHAVE_ARGS: -i test/acceptance/features/${{ matrix.feature }} --tags=~@disable-github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIMAZA_CONTROLLER_IMAGE_REF: primaza-controller:latest
+          PRIMAZA_AGENTAPP_IMAGE_REF: agentapp:latest
+          PRIMAZA_AGENTSVC_IMAGE_REF: agentsvc:latest
 
       - uses: actions/upload-artifact@v3
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,40 @@
+# Testing Primaza
+
+Primaza has both unit tests and acceptance tests to ensure that we don't break
+user scenarios during development.
+
+## Unit tests
+
+To run primaza's unit tests, run:
+```bash
+make test
+```
+
+## Acceptance tests
+
+You'll need a recent copy of `kind` to run acceptance tests.  In the future, we
+will likely lift this restriction and allow users to test against provided
+clusters.
+
+To run primaza's acceptance tests, run:
+```bash
+make test-acceptance
+```
+
+The test runner will run each of the scenarios under
+`test/acceptance/features/` and check if they pass.  Failing scenaios will be
+reported upon test completion.
+
+### Environment variables
+
+Acceptance tests can be controlled with a few key environment variables:
+
+- `PRIMAZA_CONTROLLER_IMAGE_REF`: use the image provided as the primaza controller.  Defaults to `primaza-controller:latest`
+- `PRIMAZA_AGENTAPP_IMAGE_REF`: use the image provided as the application agent controller.  Defaults to `agentapp:latest`
+- `PRIMAZA_AGENTSVC_IMAGE_REF`: use the image provided as the service agent controller.  Defaults to `agentsvc:latest`
+- `PULL_IMAGES`: due to technical restrictions related to our use of `kind`,
+  images need to be in the local docker registry in order to be tested.  To
+  ensure these images exist locally, set this env var to have the test runner
+  pull these images before running test scenarios.
+
+  The default behavior is not to pull images.

--- a/config/agents/svc/default/kustomization.yaml
+++ b/config/agents/svc/default/kustomization.yaml
@@ -4,3 +4,7 @@ resources:
 - ../namespace
 - ../agent
 namespace: services
+images:
+- name: agentsvc
+  newName: agentsvc
+  newTag: latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,7 +11,6 @@ kind: Kustomization
 #   --from-literal agentsvc-image=ghcr.io/primaza/primaza-agentsvc:latest
 configMapGenerator:
 - behavior: merge
-  literals: []
   name: manager-config
   options:
     disableNameSuffixHash: true

--- a/make/acceptance-tests.mk
+++ b/make/acceptance-tests.mk
@@ -11,6 +11,53 @@ else
 TEST_ACCEPTANCE_TAGS_ARG ?= --tags="~@disabled"
 endif
 
+ACCEPTANCE_TEST_TARGETS := test-acceptance test-acceptance-dr test-acceptance-x test-acceptance-wip test-acceptance-wip-x
+
+$(ACCEPTANCE_TEST_TARGETS): ensure-agentsvc-image ensure-agentapp-image ensure-controller-image
+
+ifeq ($(origin PRIMAZA_CONTROLLER_IMAGE_REF), undefined)
+export PRIMAZA_CONTROLLER_IMAGE_REF = primaza-controller:latest
+endif
+ifeq ($(origin PRIMAZA_AGENTAPP_IMAGE_REF), undefined)
+export PRIMAZA_AGENTAPP_IMAGE_REF = agentapp:latest
+endif
+ifeq ($(origin PRIMAZA_AGENTSVC_IMAGE_REF), undefined)
+export PRIMAZA_AGENTSVC_IMAGE_REF ?= agentsvc:latest
+endif
+
+.PHONY: ensure-controller-image
+ensure-controller-image:
+ifeq ($(origin PRIMAZA_CONTROLLER_IMAGE_REF), file)
+	$(MAKE) primaza docker-build IMG=$(PRIMAZA_CONTROLLER_IMAGE_REF)
+else
+ifneq ($(origin PULL_IMAGES), undefined)
+	docker pull $(PRIMAZA_CONTROLLER_IMAGE_REF)
+endif
+endif
+	@echo "using $(PRIMAZA_CONTROLLER_IMAGE_REF) as primaza controller"
+
+.PHONY: ensure-agentapp-image
+ensure-agentapp-image:
+ifeq ($(origin PRIMAZA_AGENTAPP_IMAGE_REF), file)
+	$(MAKE) agentapp docker-build IMG=$(PRIMAZA_AGENTAPP_IMAGE_REF)
+else
+ifneq ($(origin PULL_IMAGES), undefined)
+	docker pull $(PRIMAZA_AGENTAPP_IMAGE_REF)
+endif
+endif
+	@echo "using $(PRIMAZA_AGENTAPP_IMAGE_REF) as application agent"
+
+.PHONY: ensure-agentsvc-image
+ensure-agentsvc-image:
+ifeq ($(origin PRIMAZA_AGENTSVC_IMAGE_REF), file)
+	$(MAKE) agentsvc docker-build IMG=$(PRIMAZA_AGENTSVC_IMAGE_REF)
+else
+ifneq ($(origin PULL_IMAGES), undefined)
+	docker pull $(PRIMAZA_AGENTSVC_IMAGE_REF)
+endif
+endif
+	@echo "using $(PRIMAZA_AGENTSVC_IMAGE_REF) as service agent"
+
 .PHONY: setup-venv
 setup-venv: ## Setup virtual environment
 	python3 -m venv $(PYTHON_VENV_DIR)

--- a/make/primaza/deploy.mk
+++ b/make/primaza/deploy.mk
@@ -15,7 +15,8 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image primaza-controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set health-check-interval ${HEALTH_CHECK_INTERVAL}
 	cd config/default && $(KUSTOMIZE) edit set namespace $(NAMESPACE)
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 	kubectl rollout status -n $(NAMESPACE) deploy/primaza-controller-manager -w --timeout=120s

--- a/make/primaza/primaza.mk
+++ b/make/primaza/primaza.mk
@@ -42,7 +42,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= primaza-controller:latest
 
 .PHONY: all
 all: build

--- a/test/acceptance/features/environment.py
+++ b/test/acceptance/features/environment.py
@@ -15,8 +15,7 @@ before_all(context), after_all(context)
 
 from behave import fixture, use_fixture
 from steps.kind import KindProvider
-from steps.util import scenario_id
-import os
+from steps.util import scenario_id, get_env
 
 
 def is_development(context):
@@ -41,5 +40,10 @@ def before_scenario(context, _scenario):
 
 
 def before_all(context):
-    assert os.getenv("HOME") is not None, "Need $HOME set to run tests"
-    assert os.getenv("USER") is not None, "Need $USER set to run tests"
+    get_env("HOME")
+    get_env("USER")
+
+    for env in ["PRIMAZA_CONTROLLER_IMAGE_REF", "PRIMAZA_AGENTSVC_IMAGE_REF", "PRIMAZA_AGENTAPP_IMAGE_REF"]:
+        # assert they exist
+        value = get_env(env)
+        print(f"{env} = {value}")

--- a/test/acceptance/features/steps/util.py
+++ b/test/acceptance/features/steps/util.py
@@ -23,7 +23,6 @@ def substitute_scenario_id(context, text="$scenario_id"):
 def get_env(env):
     value = os.getenv(env)
     assert env is not None, f"{env} environment variable needs to be set"
-    print(f"{env} = {value}")
     return value
 
 


### PR DESCRIPTION
This allows for primaza's acceptance test suite to run against pre-built images, controlled with a set of environment variables.  See `TESTING.md` for documentation.