### PR TITLE
Enable merge groups as CI-triggering event

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,6 +1,7 @@
 name: PR checks
 
 on: # yamllint disable-line rule:truthy
+  merge_group: {}
   pull_request:
     branches:
       - main
@@ -11,9 +12,6 @@ on: # yamllint disable-line rule:truthy
       - "LICENSE"
       - "OWNERS"
       - "PROJECT"
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -5,6 +5,7 @@ permissions:
   security-events: write
 
 on: # yamllint disable-line rule:truthy
+  merge_group: {}
   pull_request:
     paths-ignore:
       - "docs/**"


### PR DESCRIPTION
To use github's merge queues, we need to have some actions marked as triggered by merge queues.  This enables pr checks and security checks to be run during the merge queue.

Documentation: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue