### PR TITLE
don't run acceptance tests on push to main

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -11,9 +11,6 @@ on: # yamllint disable-line rule:truthy
       - "LICENSE"
       - "OWNERS"
       - "PROJECT"
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Since we enforce that PRs are up-to-date before they can be merged, this is a redundant check.