### PR TITLE
External clusters

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -144,8 +144,8 @@ jobs:
 
       - name: Build images
         run: |
-          make ${{ matrix.make }} docker-build IMG=${{ matrix.image-name }}:latest
-          docker save ${{ matrix.image-name }}:latest -o ${{ matrix.image-name }}.tar
+          make ${{ matrix.make }} docker-build IMG=${{ matrix.image-name }}:testing
+          docker save ${{ matrix.image-name }}:testing -o ${{ matrix.image-name }}.tar
 
       - name: Upload image artifacts
         uses: actions/upload-artifact@v3
@@ -192,17 +192,44 @@ jobs:
 
       - name: Acceptance tests
         timeout-minutes: 60
-        run: |
-          docker load -i images/primaza-controller.tar
-          docker load -i images/agentapp.tar
-          docker load -i images/agentsvc.tar
-          make kustomize test-acceptance
         env:
-          EXTRA_BEHAVE_ARGS: -i test/acceptance/features/${{ matrix.feature }} --tags=~@disable-github-actions
+          EXTRA_BEHAVE_ARGS: -i test/acceptance/features/${{ matrix.feature }} -k --tags=~@disable-github-actions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PRIMAZA_CONTROLLER_IMAGE_REF: primaza-controller:latest
-          PRIMAZA_AGENTAPP_IMAGE_REF: agentapp:latest
-          PRIMAZA_AGENTSVC_IMAGE_REF: agentsvc:latest
+          PRIMAZA_CONTROLLER_IMAGE_REF: primaza-controller:testing
+          PRIMAZA_AGENTAPP_IMAGE_REF: agentapp:testing
+          PRIMAZA_AGENTSVC_IMAGE_REF: agentsvc:testing
+          CLUSTER_PROVIDER: external
+          MAIN_KUBECONFIG: out/main-kubeconfig
+          WORKER_KUBECONFIG: out/worker-kubeconfig
+        run: |
+          # ensure out/ exists
+          mkdir out/
+
+          # we need yq
+          make yq
+          echo "##[group]Creating clusters"
+            kind create cluster --name main
+            kind create cluster --name worker
+            kind get kubeconfig --name main > ${MAIN_KUBECONFIG}
+            kind get kubeconfig --name worker > ${WORKER_KUBECONFIG}
+
+            # we need to rewrite the server addresses so that connections from
+            # both inside and outside of docker can be established using the
+            # same config
+            bin/yq -i ".clusters[0].cluster.server = \"https://$(docker container inspect main-control-plane | bin/yq '.[0].NetworkSettings.Networks.kind.IPAddress'):6443\"" out/main-kubeconfig
+            bin/yq -i ".clusters[0].cluster.server = \"https://$(docker container inspect worker-control-plane | bin/yq '.[0].NetworkSettings.Networks.kind.IPAddress'):6443\"" out/worker-kubeconfig
+
+            kind load image-archive --name main images/primaza-controller.tar
+            kind load image-archive --name main images/agentapp.tar
+            kind load image-archive --name main images/agentsvc.tar
+            kind load image-archive --name worker images/primaza-controller.tar
+            kind load image-archive --name worker images/agentapp.tar
+            kind load image-archive --name worker images/agentsvc.tar
+          echo "##[endgroup]"
+
+          echo "##[group]Running acceptance tests"
+            make kustomize test-acceptance
+          echo "##[endgroup]"
 
       - uses: actions/upload-artifact@v3
         if: ${{ steps.check-skip-acceptance.outputs.can_skip != 'true' && always() }}

--- a/TESTING.md
+++ b/TESTING.md
@@ -12,29 +12,52 @@ make test
 
 ## Acceptance tests
 
-You'll need a recent copy of `kind` to run acceptance tests.  In the future, we
-will likely lift this restriction and allow users to test against provided
-clusters.
-
 To run primaza's acceptance tests, run:
 ```bash
 make test-acceptance
 ```
 
 The test runner will run each of the scenarios under
-`test/acceptance/features/` and check if they pass.  Failing scenaios will be
-reported upon test completion.
+`test/acceptance/features/` and check if they pass.
+Failing scenaios will be reported upon test completion.
 
-### Environment variables
+## Environment variables
 
-Acceptance tests can be controlled with a few key environment variables:
+Acceptance tests can be controlled with a few key environment variables.
+Their semantics are documented here.
 
-- `PRIMAZA_CONTROLLER_IMAGE_REF`: use the image provided as the primaza controller.  Defaults to `primaza-controller:latest`
-- `PRIMAZA_AGENTAPP_IMAGE_REF`: use the image provided as the application agent controller.  Defaults to `agentapp:latest`
-- `PRIMAZA_AGENTSVC_IMAGE_REF`: use the image provided as the service agent controller.  Defaults to `agentsvc:latest`
+### Provided images
+
+In some circumstances, it may be useful to provide pre-built images for use in
+acceptance testing, rather than building images during acceptance tests.
+These environment variables control which images are used and how they interact
+with testing.
+
+- `PRIMAZA_CONTROLLER_IMAGE_REF`: use the image provided as the primaza controller.
+  Defaults to `primaza-controller:latest`
+- `PRIMAZA_AGENTAPP_IMAGE_REF`: use the image provided as the application agent controller.
+  Defaults to `agentapp:latest`
+- `PRIMAZA_AGENTSVC_IMAGE_REF`: use the image provided as the service agent
+  controller.  Defaults to `agentsvc:latest`
 - `PULL_IMAGES`: due to technical restrictions related to our use of `kind`,
-  images need to be in the local docker registry in order to be tested.  To
-  ensure these images exist locally, set this env var to have the test runner
-  pull these images before running test scenarios.
+  images need to be in the local docker registry in order to be tested.
+  To ensure these images exist locally, set this env var to have the test
+  runner pull these images before running test scenarios.
 
   The default behavior is not to pull images.
+
+### Testing against provided clusters
+
+By default, the acceptance test suite will spin up and down `kind` clusters during the course of testing.
+These clusters can be slow to start and stop, which can add up significantly with the number of acceptance tests we have.
+
+As a way to make testing faster, the test suite can use external clusters instead of the ephemeral `kind` clusters.
+There are a few environment variables that control how these clusters are provided.
+
+- `CLUSTER_PROVIDER` sets which cluster provider to use.  Currently accepted values are:
+    - `kind` - uses ephemeral clusters provided by `kind`
+    - `external` - uses persistent clusters using the provided kubeconfigs
+- `MAIN_KUBECONFIG` points to a kubeconfig manifest.  The cluster pointed to
+  corresponds to the primaza cluster in acceptance tests.
+- `WORKER_KUBECONFIG` points to a kubeconfig manifest.  The cluster pointed to
+  corresponds to the worker cluster in acceptance tests.

--- a/controllers/clusterenvironment_controller.go
+++ b/controllers/clusterenvironment_controller.go
@@ -144,7 +144,8 @@ func (r *ClusterEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if ce.HasDeletionTimestamp() {
 		if controllerutil.ContainsFinalizer(ce, clusterEnvironmentFinalizer) {
 			// run finalizer
-			if err := r.finalizeClusterEnvironment(ctx, ce); err != nil {
+			err := r.finalizeClusterEnvironment(ctx, ce)
+			if client.IgnoreNotFound(err) != nil {
 				return ctrl.Result{}, err
 			}
 
@@ -158,8 +159,7 @@ func (r *ClusterEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	// add finalizer if needed
-	if !controllerutil.ContainsFinalizer(ce, clusterEnvironmentFinalizer) {
-		controllerutil.AddFinalizer(ce, clusterEnvironmentFinalizer)
+	if controllerutil.AddFinalizer(ce, clusterEnvironmentFinalizer) {
 		if err := r.Update(ctx, ce); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/controllers/serviceclaim_controller.go
+++ b/controllers/serviceclaim_controller.go
@@ -105,10 +105,9 @@ func (r *ServiceClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, nil
 	}
 
-	l.Info("Add Finalizer if needed")
 	// add finalizer if needed
-	if !controllerutil.ContainsFinalizer(&sclaim, ServiceClaimFinalizer) {
-		controllerutil.AddFinalizer(&sclaim, ServiceClaimFinalizer)
+	l.Info("Add Finalizer if needed")
+	if controllerutil.AddFinalizer(&sclaim, ServiceClaimFinalizer) {
 		if err := r.Update(ctx, &sclaim); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -262,7 +261,7 @@ func (r *ServiceClaimReconciler) getEnvironmentFromClusterEnvironment(
 	objectKey := types.NamespacedName{Name: clusterEnvironmentName, Namespace: namespace}
 	if err := r.Get(ctx, objectKey, ce); err != nil {
 		l.Info("unable to retrieve ClusterEnvironment", "error", err)
-		return nil, client.IgnoreNotFound(err)
+		return nil, err
 	}
 
 	return ce, nil

--- a/controllers/serviceclass_controller.go
+++ b/controllers/serviceclass_controller.go
@@ -25,7 +25,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	primazaiov1alpha1 "github.com/primaza/primaza/api/v1alpha1"
 	"github.com/primaza/primaza/pkg/envtag"
@@ -53,8 +52,6 @@ type ServiceClassReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0/pkg/reconcile
 func (r *ServiceClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
-
 	sc := &primazaiov1alpha1.ServiceClass{}
 	if err := r.Get(ctx, req.NamespacedName, sc, &client.GetOptions{}); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -78,8 +75,7 @@ func (r *ServiceClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// add finalizer if needed
-	if !controllerutil.ContainsFinalizer(sc, clusterEnvironmentFinalizer) {
-		controllerutil.AddFinalizer(sc, clusterEnvironmentFinalizer)
+	if controllerutil.AddFinalizer(sc, clusterEnvironmentFinalizer) {
 		if err := r.Update(ctx, sc); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/make/acceptance-tests.mk
+++ b/make/acceptance-tests.mk
@@ -5,22 +5,30 @@ TEST_ACCEPTANCE_CLI ?= kubectl
 TEST_ACCEPTANCE_PARALLEL ?= 4
 TEST_ACCEPTANCE_TAGS ?=
 
+PRIMAZA_CONTROLLER_IMAGE_REF ?= primaza-controller:latest
+PRIMAZA_AGENTAPP_IMAGE_REF ?= agentapp:latest
+PRIMAZA_AGENTSVC_IMAGE_REF ?= agentsvc:latest
+CLUSTER_PROVIDER ?= kind
+export PRIMAZA_CONTROLLER_IMAGE_REF
+export PRIMAZA_AGENTAPP_IMAGE_REF
+export PRIMAZA_AGENTSVC_IMAGE_REF
+export CLUSTER_PROVIDER
+
 ifdef TEST_ACCEPTANCE_TAGS
 TEST_ACCEPTANCE_TAGS_ARG ?= --tags="~@disabled" --tags="$(TEST_ACCEPTANCE_TAGS)"
 else
 TEST_ACCEPTANCE_TAGS_ARG ?= --tags="~@disabled"
 endif
 
+# Some tests can't be run unless we have full control of the cluster.  These
+# tests have been tagged with @kind to allow disabling their use.
+ifneq ($(CLUSTER_PROVIDER), kind)
+TEST_ACCEPTANCE_TAGS_ARG += --tags=~@kind
+endif
+
 ACCEPTANCE_TEST_TARGETS := test-acceptance test-acceptance-dr test-acceptance-x test-acceptance-wip test-acceptance-wip-x
 
 $(ACCEPTANCE_TEST_TARGETS): ensure-agentsvc-image ensure-agentapp-image ensure-controller-image
-
-PRIMAZA_CONTROLLER_IMAGE_REF ?= primaza-controller:latest
-PRIMAZA_AGENTAPP_IMAGE_REF ?= agentapp:latest
-PRIMAZA_AGENTSVC_IMAGE_REF ?= agentsvc:latest
-export PRIMAZA_CONTROLLER_IMAGE_REF
-export PRIMAZA_AGENTAPP_IMAGE_REF
-export PRIMAZA_AGENTSVC_IMAGE_REF
 
 .PHONY: ensure-controller-image
 ensure-controller-image:

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -62,7 +62,10 @@ yq: $(YQ) ## Download envtest-setup locally if necessary.
 $(YQ): $(LOCALBIN)
 	test -s $(YQ) || GOBIN=$(LOCALBIN) $(GO) install github.com/mikefarah/yq/v4@$(YQ_VERSION)
 
+$(OUTPUT_DIR)/cert-manager-$(CERTMANAGER_VERSION).yaml:
+	curl -Lo $(OUTPUT_DIR)/cert-manager-$(CERTMANAGER_VERSION).yaml https://github.com/cert-manager/cert-manager/releases/download/$(CERTMANAGER_VERSION)/cert-manager.yaml
+
 .PHONY: deploy-cert-manager
-deploy-cert-manager:
-	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERTMANAGER_VERSION)/cert-manager.yaml
+deploy-cert-manager: $(OUTPUT_DIR)/cert-manager-$(CERTMANAGER_VERSION).yaml
+	kubectl apply -f $(OUTPUT_DIR)/cert-manager-$(CERTMANAGER_VERSION).yaml
 	kubectl rollout status -n cert-manager deploy/cert-manager-webhook -w --timeout=120s

--- a/test/acceptance/features/clusterEnvironmentHealthcheck.feature
+++ b/test/acceptance/features/clusterEnvironmentHealthcheck.feature
@@ -52,6 +52,7 @@ Feature: ClusterEnvironment's Healthchecks
         Then On Primaza Cluster "main", ClusterEnvironment "worker" state will eventually move to "Offline"
         And On Primaza Cluster "main", ClusterEnvironment "worker" status condition with Type "Online" has Reason "ErrorDuringHealthCheck"
 
+    @kind
     Scenario: Status change for ClusterEnvironment: Worker cluster is deleted
         When Worker Cluster "worker" is deleted
         Then On Primaza Cluster "main", ClusterEnvironment "worker" state will eventually move to "Offline"

--- a/test/acceptance/features/steps/persistent_clusters.py
+++ b/test/acceptance/features/steps/persistent_clusters.py
@@ -1,0 +1,371 @@
+import os
+from steps.command import Command
+from steps.clusterprovider import ClusterProvider
+from steps.clusterprovisioner import ClusterProvisioner
+from steps.primazacluster import PrimazaCluster
+from steps.workercluster import WorkerCluster
+from steps.util import get_env
+
+
+class PersistentClusterProvider(ClusterProvider):
+
+    def __init__(self, cluster_kubeconfig: str, worker_kubeconfig: str):
+        super().__init__()
+        self.__cluster_kubeconfig = cluster_kubeconfig
+        self.__worker_kubeconfig = worker_kubeconfig
+
+    def build_primaza_cluster(self, _name, _version):
+        return PersistentPrimazaCluster(kubeconfig_path=self.__cluster_kubeconfig)
+
+    def build_worker_cluster(self, _name, _version):
+        return PersistentWorkerCluster(kubeconfig_path=self.__worker_kubeconfig)
+
+    def __cluster_name(self, name: str) -> str:
+        return f"{self.__prefix}{name}"
+
+    def join_networks(self, _cluster1: str, _cluster2: str):
+        # assume for now that the two clusters can talk to each other
+        # TODO(sadlerap): actually check that connections can be established, maybe have them ping(8) each other?
+        pass
+
+
+class PersistentClusterProvisioner(ClusterProvisioner):
+    def __init__(self, kubeconfig_path: str):
+        self.__kubeconfig_path = kubeconfig_path
+
+    def exec(self, command: str) -> (str, int):
+        cmd = Command()
+        output, exit_code = cmd.run(command)
+        return output, exit_code
+
+    def start(self, _timeout_sec: int = 600):
+        # the cluster is already started, so nothing to do
+        return "", 0
+
+    def delete(self):
+        # we're going to let the cluster manage it's own lifecycle, since we
+        # don't necessarily know how to delete it.
+        pass
+
+    def kubeconfig(self, internal: bool = False) -> str:
+        _ = internal
+        with open(self.__kubeconfig_path, "r") as config:
+            data = config.read()
+            return data
+
+
+class PersistentPrimazaCluster(PrimazaCluster):
+    __controller_image: str = get_env("PRIMAZA_CONTROLLER_IMAGE_REF")
+    __agentapp_image: str = get_env("PRIMAZA_AGENTAPP_IMAGE_REF")
+    __agentsvc_image: str = get_env("PRIMAZA_AGENTSVC_IMAGE_REF")
+    __has_controller_install: bool = False
+    __has_agentapp_install: bool = False
+    __has_agentsvc_install: bool = False
+
+    def __init__(self, kubeconfig_path: str):
+        self.__kubeconfig_path = kubeconfig_path
+        super().__init__(PersistentClusterProvisioner(kubeconfig_path), "controller")
+
+    def delete(self):
+        cmd = Command() \
+            .setenv("KUBECONFIG", self.__kubeconfig_path)
+        for namespace in self.agentapp_namespaces:
+            print(f"deleting application namespace in primaza cluster {self.cluster_name}: {namespace}")
+            self.cleanup_application_namespace(namespace)
+        for namespace in self.agentsvc_namespaces:
+            print(f"deleting service namespace in primaza cluster {self.cluster_name}: {namespace}")
+            self.cleanup_service_namespace(namespace)
+
+        if self.__has_controller_install:
+            print(f"deleting controller namespace in primaza cluster {self.cluster_name}: {self.primaza_namespace}")
+            namespace = self.primaza_namespace
+            self.cleanup_controller_namespace(namespace)
+            out, err = cmd \
+                .run(f"make primaza undeploy ignore-not-found=1 NAMESPACE={namespace}")
+            assert err == 0, f"failed to cleanup test namespace {namespace}"
+
+        # there's a potential for crds to overlap between agents and the
+        # primaza controller. For instance, the primaza controller requires the
+        # registeredservice crd to exist.  To avoid removal conflicts, run
+        # agent undeployment after controller cleanup.
+        for namespace in self.agentapp_namespaces:
+            out, err = cmd \
+                .run(f"make agentapp undeploy ignore-not-found=1 NAMESPACE={namespace}")
+            assert err == 0, f"failed to cleanup application namespace {namespace}"
+        for namespace in self.agentsvc_namespaces:
+            out, err = cmd \
+                .run(f"make agentsvc undeploy ignore-not-found=1 NAMESPACE={namespace}")
+            assert err == 0, f"failed to cleanup service namespace {namespace}"
+
+    def cleanup_controller_namespace(self, namespace: str):
+        cmd = Command().setenv("KUBECONFIG", self.__kubeconfig_path)
+
+        # cluster environments need to come last, since the other resource
+        # controllers can fall over if cluster environments are removed before
+        # they are.
+        resource_names = ["registeredservices", "servicecatalogs", "serviceclaims", "serviceclasses", "clusterenvironments"]
+        resources = list(map(lambda s: f"{s}.primaza.io", resource_names))
+        for crd in resources:
+            names, _ = cmd.run(f"kubectl get {crd} -o name -n {namespace}")
+            for resource in names.splitlines():
+                patch = '{"metadata": {"finalizers": []}}'
+                cmd.run(f'kubectl delete -n {namespace} {resource} --force --timeout=60s')
+                cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+        x = ",".join(resources)
+        out, err = cmd.run(f"kubectl delete -n {namespace} {x} --all --ignore-not-found")
+        assert err == 0, "failed to run command!"
+
+        # delete any deployments in the namespace
+        cmd.run(f"kubectl delete -n {namespace} deployments --all --ignore-not-found --timeout=30s")
+        names, _ = cmd.run(f"kubectl get deployments.apps -o name -n {namespace}")
+        for resource in names.splitlines():
+            patch = '{"metadata": {"finalizers": []}}'
+            cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+
+    def cleanup_service_namespace(self, namespace: str):
+        cmd = Command().setenv("KUBECONFIG", self.__kubeconfig_path)
+
+        resourcelist = "serviceclasses.primaza.io"
+        names, _ = cmd.run(f"kubectl get {resourcelist} -o name -n {namespace}")
+        for resource in names.splitlines():
+            patch = '{"metadata": {"finalizers": []}}'
+            cmd.run(f'kubectl delete -n {namespace} {resource} --force --timeout=60s')
+            cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+        out, err = cmd.run(f"kubectl delete -n {namespace} {resourcelist} --all --ignore-not-found")
+        assert err == 0, "failed to run command!"
+
+        # delete any deployments in the namespace
+        cmd.run(f"kubectl delete -n {namespace} deployments --all --ignore-not-found --timeout=30s")
+        names, _ = cmd.run(f"kubectl get deployments.apps -o name -n {namespace}")
+        for resource in names.splitlines():
+            patch = '{"metadata": {"finalizers": []}}'
+            cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+
+    def cleanup_application_namespace(self, namespace: str):
+        cmd = Command().setenv("KUBECONFIG", self.__kubeconfig_path)
+
+        resource_names = ["servicebindings", "servicecatalogs", "serviceclaims"]
+        resources = list(map(lambda s: f"{s}.primaza.io", resource_names))
+
+        # for resiliency, patch out finalizers.  There may be bugs in the
+        # controller, and we don't want to rely on finalizers working correctly
+        # for testing to work.
+        for crd in resources:
+            names, _ = cmd.run(f"kubectl get {crd} -o name -n {namespace}")
+            for resource in names.splitlines():
+                patch = '{"metadata": {"finalizers": []}}'
+                cmd.run(f'kubectl delete -n {namespace} {resource} --force --timeout=60s')
+                cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+        resourcelist = ",".join(resources)
+        out, err = cmd.run(f"kubectl delete -n {namespace} {resourcelist} --all --ignore-not-found")
+        assert err == 0, "failed to run command!"
+
+        # delete any deployments in the namespace
+        cmd.run(f"kubectl delete -n {namespace} deployments --all --ignore-not-found --timeout=30s")
+        names, _ = cmd.run(f"kubectl get deployments.apps -o name -n {namespace}")
+        for resource in names.splitlines():
+            patch = '{"metadata": {"finalizers": []}}'
+            cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+
+    def install_primaza(self):
+        img = self.__controller_image
+        kubeconfig = self.__kubeconfig_path
+
+        self.__build_load_and_deploy_primaza(kubeconfig, img, self.primaza_namespace)
+        self.__has_controller_install = True
+
+    def __build_load_and_deploy_primaza(self, kubeconfig_path: str, img: str, namespace: str):
+        self.__install_dependencies(kubeconfig_path)
+        self.__deploy_primaza(kubeconfig_path, img, namespace)
+
+    def __install_dependencies(self, kubeconfig_path: str):
+        out, err = Command() \
+            .setenv("KUBECONFIG", kubeconfig_path) \
+            .run("make deploy-cert-manager")
+        print(out)
+        assert err == 0, "error installing dependencies"
+
+    def __deploy_primaza(self, kubeconfig_path: str, img: str, namespace: str):
+        out, err = self.__build_install_base_cmd(kubeconfig_path, img) \
+            .setenv("NAMESPACE", namespace) \
+            .run("make primaza deploy")
+        print(out)
+        assert err == 0, f"error deploying Primaza's controller into cluster {self.cluster_name}"
+
+    def __build_install_base_cmd(self, kubeconfig_path: str, img: str) -> Command:
+        return Command() \
+            .setenv("HOME", os.getenv("HOME")) \
+            .setenv("USER", os.getenv("USER")) \
+            .setenv("KUBECONFIG", kubeconfig_path) \
+            .setenv("GOCACHE", os.getenv("GOCACHE", "/tmp/gocache")) \
+            .setenv("GOPATH", os.getenv("GOPATH", "/tmp/go")) \
+            .setenv("IMG", img)
+
+    def deploy_agentsvc(self, namespace: str):
+        """
+        Deploys the Service Agent into a cluster's namespace
+        """
+        image = self.__agentsvc_image
+        self.__install_agentsvc_crd(self.__kubeconfig_path, image)
+        self.__deploy_agentsvc(self.__kubeconfig_path, image, namespace)
+        self.__has_agentsvc_install = True
+        self.agentsvc_namespaces.add(namespace)
+
+    def deploy_agentapp(self, namespace: str):
+        """
+        Deploys Application Agent into a cluster's namespace
+        """
+        image = self.__agentapp_image
+        self.__install_agentapp_crd(self.__kubeconfig_path, image)
+        self.__deploy_agentapp(self.__kubeconfig_path, image, namespace)
+        self.__has_agentapp_install = True
+        self.agentapp_namespaces.add(namespace)
+
+    def __install_agentapp_crd(self, kubeconfig_path: str, image: str):
+        out, err = self.__build_install_base_cmd(kubeconfig_path, image).run("make agentapp install")
+        print(out)
+        assert err == 0, "error installing manifests and building agent app  controller"
+
+    def __install_agentsvc_crd(self, kubeconfig_path: str, image: str):
+        out, err = self.__build_install_base_cmd(kubeconfig_path, image).run("make agentsvc install")
+        print(out)
+        assert err == 0, "error installing manifests and building agent svc  controller"
+
+    def __deploy_agentapp(self, kubeconfig_path: str, img: str, namespace: str):
+        out, err = self.__build_install_base_cmd(kubeconfig_path, img) \
+            .setenv("IMG", img) \
+            .setenv("NAMESPACE", namespace) \
+            .run("make agentapp deploy")
+        print(out)
+        assert err == 0, f"error deploying Agent app's controller into cluster {self.cluster_name}"
+
+    def __deploy_agentsvc(self, kubeconfig_path: str, img: str, namespace: str):
+        out, err = self.__build_install_base_cmd(kubeconfig_path, img) \
+            .setenv("IMG", img) \
+            .setenv("NAMESPACE", namespace) \
+            .run("make agentsvc deploy")
+        print(out)
+        assert err == 0, f"error deploying Agent app's controller into cluster {self.cluster_name}"
+
+
+class PersistentWorkerCluster(WorkerCluster):
+    __agentapp_loaded: bool = False
+    __agentsvc_loaded: bool = False
+    __agentapp_image: str = get_env("PRIMAZA_AGENTAPP_IMAGE_REF")
+    __agentsvc_image: str = get_env("PRIMAZA_AGENTSVC_IMAGE_REF")
+
+    def __init__(self, kubeconfig_path: str):
+        self.__kubeconfig_path = kubeconfig_path
+        super().__init__(PersistentClusterProvisioner(kubeconfig_path), "worker")
+
+    def delete(self):
+        cmd = Command() \
+            .setenv("KUBECONFIG", self.__kubeconfig_path)
+        for namespace in self.agentapp_namespaces:
+            print(f"deleting application namespace in worker cluster {self.cluster_name}: {namespace}")
+            self.cleanup_application_namespace(namespace)
+        for namespace in self.agentsvc_namespaces:
+            print(f"deleting service namespace in worker cluster {self.cluster_name}: {namespace}")
+            self.cleanup_service_namespace(namespace)
+        for namespace in self.agentapp_namespaces:
+            out, err = cmd \
+                .setenv("NAMESPACE", namespace) \
+                .run("make agentapp undeploy ignore-not-found=1")
+            assert err == 0, f"failed to cleanup application namespace {namespace}"
+        for namespace in self.agentsvc_namespaces:
+            out, err = cmd \
+                .setenv("NAMESPACE", namespace) \
+                .run("make agentsvc undeploy ignore-not-found=1")
+            assert err == 0, f"failed to cleanup service namespace {namespace}"
+
+    def cleanup_service_namespace(self, namespace: str):
+        cmd = Command().setenv("KUBECONFIG", self.__kubeconfig_path)
+
+        resourcelist = "serviceclasses.primaza.io"
+        names, _ = cmd.run(f"kubectl get {resourcelist} -o name -n {namespace}")
+        for resource in names.splitlines():
+            patch = '{"metadata": {"finalizers": []}}'
+            cmd.run(f'kubectl delete -n {namespace} {resource} --force --timeout=60s')
+            cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+        out, err = cmd.run(f"kubectl delete -n {namespace} {resourcelist} --all --ignore-not-found")
+        assert err == 0, "failed to run command!"
+
+        # delete any deployments in the namespace
+        cmd.run(f"kubectl delete -n {namespace} deployments --all --ignore-not-found --timeout=30s")
+        names, _ = cmd.run(f"kubectl get deployments.apps -o name -n {namespace}")
+        for resource in names.splitlines():
+            patch = '{"metadata": {"finalizers": []}}'
+            cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+
+    def cleanup_application_namespace(self, namespace: str):
+        cmd = Command().setenv("KUBECONFIG", self.__kubeconfig_path)
+
+        resource_names = ["servicebindings", "servicecatalogs", "serviceclaims"]
+        resources = list(map(lambda s: f"{s}.primaza.io", resource_names))
+
+        # for resiliency, patch out finalizers.  There may be bugs in the
+        # controller, and we don't want to rely on finalizers working correctly
+        # for testing to work.
+        for crd in resources:
+            names, _ = cmd.run(f"kubectl get {crd} -o name -n {namespace}")
+            for resource in names.splitlines():
+                patch = '{"metadata": {"finalizers": []}}'
+                cmd.run(f'kubectl delete -n {namespace} {resource} --force --timeout=60s')
+                cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+        resourcelist = ",".join(resources)
+        out, err = cmd.run(f"kubectl delete -n {namespace} {resourcelist} --all --ignore-not-found")
+        assert err == 0, "failed to run command!"
+
+        # delete any deployments in the namespace
+        cmd.run(f"kubectl delete -n {namespace} deployments --all --ignore-not-found --timeout=30s")
+        names, _ = cmd.run(f"kubectl get deployments.apps -o name -n {namespace}")
+        for resource in names.splitlines():
+            patch = '{"metadata": {"finalizers": []}}'
+            cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+
+    def __deploy_agentapp(self, kubeconfig_path: str, image: str, namespace: str):
+        out, err = self.__build_install_base_cmd(kubeconfig_path, image).setenv("NAMESPACE", namespace).run("make agentapp deploy")
+        print(out)
+        assert err == 0, f"error deploying Agent app's controller into cluster {self.cluster_name}"
+
+    def __deploy_agentsvc(self, kubeconfig_path: str, img: str, namespace: str):
+        out, err = self.__build_install_base_cmd(kubeconfig_path, img).setenv("NAMESPACE", namespace).run("make agentsvc deploy")
+        print(out)
+        assert err == 0, f"error deploying Agent app's controller into cluster {self.cluster_name}"
+
+    def __install_agentapp_crd(self, kubeconfig_path: str):
+        out, err = self.__build_install_base_cmd(kubeconfig_path, self.__agentapp_image) \
+            .run("make agentapp install")
+        print(out)
+        assert err == 0, "error installing manifests and building agent app controller"
+
+    def __install_agentsvc_crd(self, kubeconfig_path: str):
+        out, err = self.__build_install_base_cmd(kubeconfig_path, self.__agentsvc_image) \
+            .run("make agentsvc install")
+        print(out)
+        assert err == 0, "error installing manifests and building agent svc controller"
+
+    def __build_install_base_cmd(self, kubeconfig_path: str, image: str) -> Command:
+        return Command() \
+            .setenv("KUBECONFIG", kubeconfig_path) \
+            .setenv("GOCACHE", os.getenv("GOCACHE", "/tmp/gocache")) \
+            .setenv("GOPATH", os.getenv("GOPATH", "/tmp/go")) \
+            .setenv("IMG", image)
+
+    def deploy_agentsvc(self, namespace: str):
+        """
+        Deploys the Service Agent into a cluster's namespace
+        """
+        image = self.__agentsvc_image
+        self.__install_agentsvc_crd(self.__kubeconfig_path)
+        self.__deploy_agentsvc(self.__kubeconfig_path, image, namespace)
+        self.agentsvc_namespaces.add(namespace)
+
+    def deploy_agentapp(self, namespace: str):
+        """
+        Deploys Application Agent into a cluster's namespace
+        """
+        image = self.__agentapp_image
+        self.__install_agentapp_crd(self.__kubeconfig_path)
+        self.__deploy_agentapp(self.__kubeconfig_path, image, namespace)
+        self.agentapp_namespaces.add(namespace)

--- a/test/acceptance/features/steps/persistent_clusters.py
+++ b/test/acceptance/features/steps/persistent_clusters.py
@@ -312,6 +312,7 @@ class PersistentWorkerCluster(WorkerCluster):
                 patch = '{"metadata": {"finalizers": []}}'
                 cmd.run(f'kubectl delete -n {namespace} {resource} --force --timeout=60s')
                 cmd.run(f'kubectl patch -n {namespace} {resource} -p \'{patch}\' --type=merge')
+
         resourcelist = ",".join(resources)
         out, err = cmd.run(f"kubectl delete -n {namespace} {resourcelist} --all --ignore-not-found")
         assert err == 0, "failed to run command!"


### PR DESCRIPTION
This implements using external, persistent clusters for use within acceptance testing.  Testing namespaces are cleaned up at the end of each scenario and remade at the beginning of each scenario.

This works best with provided images, so you'll want to set those environment variables appropriately.  In addition, you'll need to set a few environment variables to use this functionality:
- `CLUSTER_PROVIDER` informs the testing framework which cluster provider to use.  Allowed options are either `kind` or `external`.
- `CLUSTER_KUBECONFIG` is a path to a kubeconfig.  The cluster this points to corresponds to the primaza cluster used in testing.
- `WORKER_KUBECONFIG` is also a path to a kubeconfig.  This cluster corresponds to the worker cluster used in testing.