### PR TITLE
Give App Agent delete right on Secrets

### DIFF
--- a/config/agents/app/rbac/manager_role.yaml
+++ b/config/agents/app/rbac/manager_role.yaml
@@ -62,6 +62,7 @@ rules:
   verbs:
   - list
   - get
+  - delete
   - watch
   - update
 - apiGroups:


### PR DESCRIPTION
Application Agent needs right to delete Secrets to be able to set ServiceBinding's ownership on ServiceBinding's Secret

Signed-off-by: Francesco Ilario <filario@redhat.com>
