### PR TITLE
Ignore out/ directory when linting yaml

### DIFF
--- a/make/linters.mk
+++ b/make/linters.mk
@@ -11,7 +11,7 @@ SHELLCHECK_VERSION ?= v0.9.0
 .PHONY: lint
 lint: setup-venv lint-go lint-yaml lint-python lint-feature-files lint-conflicts lint-shell ## Runs all linters
 
-YAML_FILES := $(shell find . -path ./vendor -prune -o -path ./config -prune -o -path ./test/performance -prune -o -type f -regex ".*\.y[a]ml" -print)
+YAML_FILES := $(shell find . -path ./vendor -prune -o -path ./config -prune -o -path ./out -prune -o -path ./test/performance -prune -o -type f -regex ".*\.y[a]?ml" -print)
 .PHONY: lint-yaml
 lint-yaml: setup-venv ${YAML_FILES} ## Checks all yaml files
 	$(Q)$(PYTHON_VENV_DIR)/bin/pip install yamllint==$(YAMLLINT_VERSION)


### PR DESCRIPTION
Anything yaml under out/ is likely generated or retrieved from somewhere; linting it isn't particularly useful.  I've run into issues with the cached cert-manager manifest locally.