### PR TITLE
Fixing ServiceClaim status management in AppNs

### DIFF
--- a/api/v1alpha1/servicebinding_types.go
+++ b/api/v1alpha1/servicebinding_types.go
@@ -71,8 +71,8 @@ type ServiceBindingStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	// +kubebuilder:validation:Enum=Ready;Malformed
 	// The state of the service binding observed
+	// +kubebuilder:validation:Enum=Ready;Malformed
 	// +kubebuilder:default:=Malformed
 	State string `json:"state,omitempty"`
 

--- a/api/v1alpha1/serviceclaim_types.go
+++ b/api/v1alpha1/serviceclaim_types.go
@@ -60,12 +60,16 @@ type ServiceClaimApplicationClusterContext struct {
 
 // ServiceClaimStatus defines the observed state of ServiceClaim
 type ServiceClaimStatus struct {
+	// The state of the ServiceClaim observed
 	//+kubebuilder:validation:Enum=Pending;Resolved;Invalid
 	//+kubebuilder:default:=Pending
-	State             ServiceClaimState  `json:"state"`
-	ClaimID           string             `json:"claimID,omitempty"`
-	RegisteredService string             `json:"registeredService"`
-	Conditions        []metav1.Condition `json:"conditions,omitempty"`
+	State ServiceClaimState `json:"state"`
+	// Unique ID For the ServiceClaim
+	ClaimID string `json:"claimID,omitempty"`
+	// Name of Claimed RegisteredService
+	RegisteredService string `json:"registeredService"`
+	// The status of the service binding along with reason and type
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/primaza.io_serviceclaims.yaml
+++ b/config/crd/bases/primaza.io_serviceclaims.yaml
@@ -172,8 +172,11 @@ spec:
             description: ServiceClaimStatus defines the observed state of ServiceClaim
             properties:
               claimID:
+                description: Unique ID For the ServiceClaim
                 type: string
               conditions:
+                description: The status of the service binding along with reason and
+                  type
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -242,9 +245,11 @@ spec:
                   type: object
                 type: array
               registeredService:
+                description: Name of Claimed RegisteredService
                 type: string
               state:
                 default: Pending
+                description: The state of the ServiceClaim observed
                 enum:
                 - Pending
                 - Resolved

--- a/pkg/primaza/controlplane/application_namespaces.go
+++ b/pkg/primaza/controlplane/application_namespaces.go
@@ -40,7 +40,8 @@ func PushServiceBinding(
 	controllerruntimeClient client.Client,
 	nspace *string,
 	applicationNamespaces []string,
-	cfg *rest.Config) error {
+	cfg *rest.Config,
+) error {
 	l := log.FromContext(ctx)
 	oc := client.Options{
 		Scheme: scheme,

--- a/test/acceptance/features/claimFromAppNsPull.feature
+++ b/test/acceptance/features/claimFromAppNsPull.feature
@@ -1,4 +1,4 @@
-Feature: Claim from an application namespace
+Feature: Claim from an application namespace (Pull)
 
     Background:
         Given Primaza Cluster "main" is running
@@ -96,6 +96,8 @@ Feature: Claim from an application namespace
         Then On Primaza Cluster "main", ServiceClaim "sc-test" state will eventually move to "Resolved"
         And  On Primaza Cluster "main", RegisteredService "primaza-rsdb" state will eventually move to "Claimed"
         And  On Primaza Cluster "main", ServiceCatalog "stage" will not contain RegisteredService "primaza-rsdb"
+        And  On Worker Cluster "worker", the status of ServiceClaim "sc-test" is "Resolved"
+        And  On Worker Cluster "worker", the RegisteredService bound to the ServiceClaim "sc-test" is "primaza-rsdb"
         And  On Worker Cluster "worker", the secret "sc-test" in namespace "applications" has the key "type" with value "psqlserver"
 
     Scenario: Delete claim with label selector from an application namespace

--- a/test/acceptance/features/claimFromAppNsPush.feature
+++ b/test/acceptance/features/claimFromAppNsPush.feature
@@ -1,4 +1,4 @@
-Feature: Claim from an application namespace
+Feature: Claim from an application namespace (Push)
 
     Background:
         Given Primaza Cluster "main" is running
@@ -19,7 +19,41 @@ Feature: Claim from an application namespace
             applicationNamespaces:
             - applications
         """
-        And On Primaza Cluster "main", Resource is created
+
+    Scenario: Claim with label selector from an application namespace not resolved
+        Given On Worker Cluster "worker", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: ServiceClaim
+        metadata:
+          name: sc-test
+          namespace: applications
+        spec:
+          serviceClassIdentity:
+          - name: type
+            value: psqlserver
+          - name: provider
+            value: aws
+          serviceEndpointDefinitionKeys:
+          - host
+          - port
+          - user
+          - password
+          - database
+          environmentTag: stage
+          application:
+            kind: Deployment
+            apiVersion: apps/v1
+            selector:
+              matchLabels:
+                a: b
+                c: d
+        """
+        Then On Primaza Cluster "main", the status of ServiceClaim "sc-test" is "Pending"
+        And  On Worker Cluster "worker", the status of ServiceClaim "sc-test" is "Pending"
+
+    Scenario: Claim with label selector from an application namespace
+        Given On Primaza Cluster "main", Resource is created
         """
         apiVersion: v1
         kind: Secret
@@ -61,9 +95,7 @@ Feature: Claim from an application namespace
           sla: L3
           """
         And On Primaza Cluster "main", RegisteredService "primaza-rsdb" state will eventually move to "Available"
-
-    Scenario: Claim with label selector from an application namespace
-       Given On Worker Cluster "worker", Resource is created
+        And On Worker Cluster "worker", Resource is created
         """
         apiVersion: primaza.io/v1alpha1
         kind: ServiceClaim
@@ -91,13 +123,58 @@ Feature: Claim from an application namespace
                 a: b
                 c: d
         """
-        Then On Worker Cluster "worker", the status of ServiceClaim "sc-test" is "Resolved"
-        And On Primaza Cluster "main", RegisteredService "primaza-rsdb" state will eventually move to "Claimed"
-        And On Primaza Cluster "main", ServiceCatalog "stage" will not contain RegisteredService "primaza-rsdb"
-        And On Worker Cluster "worker", the secret "sc-test" in namespace "applications" has the key "type" with value "psqlserver"
+        Then On Primaza Cluster "main", the status of ServiceClaim "sc-test" is "Resolved"
+        And  On Primaza Cluster "main", RegisteredService "primaza-rsdb" state will eventually move to "Claimed"
+        And  On Primaza Cluster "main", ServiceCatalog "stage" will not contain RegisteredService "primaza-rsdb"
+        And  On Primaza Cluster "main", the RegisteredService bound to the ServiceClaim "sc-test" is "primaza-rsdb"
+        And  On Worker Cluster "worker", the status of ServiceClaim "sc-test" is "Resolved"
+        And  On Worker Cluster "worker", the RegisteredService bound to the ServiceClaim "sc-test" is "primaza-rsdb"
+        And  On Worker Cluster "worker", the secret "sc-test" in namespace "applications" has the key "type" with value "psqlserver"
 
     Scenario: Update claim with label selector from an application namespace
-        Given On Worker Cluster "worker", Resource is created
+        Given On Primaza Cluster "main", Resource is created
+        """
+        apiVersion: v1
+        kind: Secret
+        metadata:
+            name: $scenario_id
+            namespace: primaza-system
+        stringData:
+            password: quedicelagente
+        """
+        And On Primaza Cluster "main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: RegisteredService
+        metadata:
+          name: primaza-rsdb
+          namespace: primaza-system
+        spec:
+          constraints:
+            environments:
+            - stage
+          serviceClassIdentity:
+            - name: type
+              value: psqlserver
+            - name: provider
+              value: aws
+          serviceEndpointDefinition:
+            - name: host
+              value: mydavphost.io
+            - name: port
+              value: "5432"
+            - name: user
+              value: davp
+            - name: password
+              valueFromSecret:
+                name: $scenario_id
+                key: password
+            - name: database
+              value: davpdata
+          sla: L3
+          """
+        And On Primaza Cluster "main", RegisteredService "primaza-rsdb" state will eventually move to "Available"
+        And On Worker Cluster "worker", Resource is created
         """
         apiVersion: primaza.io/v1alpha1
         kind: ServiceClaim
@@ -161,7 +238,49 @@ Feature: Claim from an application namespace
         And jsonpath ".status.conditions[0].reason" on "serviceclaims.primaza.io/sc-test:applications" in cluster worker is "ValidationError"
 
     Scenario: Delete claim with label selector from an application namespace
-        Given On Worker Cluster "worker", Resource is created
+        Given On Primaza Cluster "main", Resource is created
+        """
+        apiVersion: v1
+        kind: Secret
+        metadata:
+            name: $scenario_id
+            namespace: primaza-system
+        stringData:
+            password: quedicelagente
+        """
+        And On Primaza Cluster "main", Resource is created
+        """
+        apiVersion: primaza.io/v1alpha1
+        kind: RegisteredService
+        metadata:
+          name: primaza-rsdb
+          namespace: primaza-system
+        spec:
+          constraints:
+            environments:
+            - stage
+          serviceClassIdentity:
+            - name: type
+              value: psqlserver
+            - name: provider
+              value: aws
+          serviceEndpointDefinition:
+            - name: host
+              value: mydavphost.io
+            - name: port
+              value: "5432"
+            - name: user
+              value: davp
+            - name: password
+              valueFromSecret:
+                name: $scenario_id
+                key: password
+            - name: database
+              value: davpdata
+          sla: L3
+          """
+        And On Primaza Cluster "main", RegisteredService "primaza-rsdb" state will eventually move to "Available"
+        And On Worker Cluster "worker", Resource is created
         """
         apiVersion: primaza.io/v1alpha1
         kind: ServiceClaim

--- a/test/acceptance/features/steps/cluster.py
+++ b/test/acceptance/features/steps/cluster.py
@@ -280,9 +280,11 @@ class Cluster(object):
         sa_name = f"primaza-{tenant}-{cluster_environment}"
         sa_namespace = "kube-system"
         role_name = f"primaza:controlplane:{nstype}"
+        svc_pmz_resources = ["serviceclasses", "registeredservices"]
+        app_pmz_resources = ["servicebindings", "servicecatalogs", "serviceclaims", "serviceclaims/status"]
         pmz_rules = [client.V1PolicyRule(
             api_groups=["primaza.io"],
-            resources=["serviceclasses", "registeredservices"] if nstype == "svc" else ["servicebindings", "servicecatalogs", "serviceclaims"],
+            resources=svc_pmz_resources if nstype == "svc" else app_pmz_resources,
             verbs=["get", "list", "watch", "create", "update", "patch", "delete"])]
 
         r = client.V1Role(

--- a/test/acceptance/features/steps/primazacluster.py
+++ b/test/acceptance/features/steps/primazacluster.py
@@ -118,6 +118,23 @@ def ensure_status_of_service_claim(context, primaza_cluster_name: str, service_c
     )
 
 
+@step(u'On Primaza Cluster "{cluster_name}", the RegisteredService bound to the ServiceClaim "{service_claim_name}" is "{registered_service}"')
+def ensure_registered_service_of_service_claim(context, cluster_name: str, service_claim_name: str, registered_service: str, tenant: str = "primaza-system"):
+    cluster = context.cluster_provider.get_primaza_cluster(cluster_name)
+    group = "primaza.io"
+    version = "v1alpha1"
+    plural = "serviceclaims"
+    polling2.poll(
+        target=lambda: cluster.read_custom_resource_status(
+            group,
+            version,
+            plural,
+            service_claim_name,
+            tenant).get("status", {}).get("registeredService", None) == registered_service,
+        step=1,
+        timeout=60)
+
+
 @step(u'On Primaza Cluster "{primaza_cluster_name}", the secret "{secret_name}" in namespace "{namespace}" has the key "{key}" with value "{value}"')
 def ensure_secret_key_has_the_right_value(context, primaza_cluster_name: str, secret_name: str, namespace: str, key: str, value: str):
     primaza_cluster = context.cluster_provider.get_primaza_cluster(primaza_cluster_name)

--- a/test/acceptance/features/steps/workercluster.py
+++ b/test/acceptance/features/steps/workercluster.py
@@ -219,6 +219,24 @@ def ensure_status_of_service_claim(context, cluster_name: str, service_claim_nam
         timeout=60)
 
 
+@step(u'On Worker Cluster "{cluster_name}", the RegisteredService bound to the ServiceClaim "{service_claim_name}" is "{registered_service}"')
+def ensure_registered_service_of_service_claim(context, cluster_name: str, service_claim_name: str, registered_service: str):
+    cluster = context.cluster_provider.get_worker_cluster(cluster_name)
+    group = "primaza.io"
+    version = "v1alpha1"
+    plural = "serviceclaims"
+    namespace = "applications"
+    polling2.poll(
+        target=lambda: cluster.read_custom_resource_status(
+            group,
+            version,
+            plural,
+            service_claim_name,
+            namespace).get("status", {}).get("registeredService", None) == registered_service,
+        step=1,
+        timeout=60)
+
+
 @step(u'On Worker Cluster "{cluster_name}", the status of RegisteredService "{name}" is "{status}"')
 def ensure_status_of_registered_service(context, cluster_name: str, name: str, status: str):
     cluster = context.cluster_provider.get_worker_cluster(cluster_name)


### PR DESCRIPTION
In [claim from an Application Namespace workflow](https://www.primaza.io/tutorials/claiming/from-application-namespace.html), the status of the ServiceClaim in the application namespace was not updated. This PR mitigates this issue by updating the status of the remote ServiceClaim if present.

Signed-off-by: Francesco Ilario <filario@redhat.com>
