### PR TITLE
ci: use go v1.21 in nightly checks

### DIFF
--- a/.github/workflows/nightly-pr-checks.yaml
+++ b/.github/workflows/nightly-pr-checks.yaml
@@ -158,6 +158,11 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: "x64"
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: Download pre-built images
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This was causing nightly testing failures, see
https://github.com/primaza/primaza/actions/runs/5885546588/job/15962174393 for an example.