### PR TITLE
Fix hardcoded repo owner

### DIFF
--- a/.github/workflows/nightly-pr-checks.yaml
+++ b/.github/workflows/nightly-pr-checks.yaml
@@ -200,7 +200,7 @@ jobs:
       uses: peter-evans/repository-dispatch@v2
       with:
         token: ${{ secrets.BOT_TOKEN }}
-        repository: mmulholla/primaza
+        repository: ${{ github.repository_owner }}/primaza
         event-type: primaza-release
         client-payload: '{"version": "nightly"}'
 


### PR DESCRIPTION
Left a hardcoded mmulholl in the nightly flow when kicking off a release